### PR TITLE
Add VoiceAssistant (dictation/tts), spoken formatter, and session persistence

### DIFF
--- a/src/components/DiagnosisResult.tsx
+++ b/src/components/DiagnosisResult.tsx
@@ -2,6 +2,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
+import { VoiceAssistant } from '@/components/voice/VoiceAssistant';
+import { formatAssessmentForSpeech } from '@/lib/spokenClinicalFormatter';
 import { ClinicalAssessment, PatientData } from '@/lib/medicalKnowledge';
 import {
   Stethoscope,
@@ -31,6 +33,8 @@ interface DiagnosisResultProps {
 }
 
 export const DiagnosisResult = ({ diagnosis, patientData, onReset }: DiagnosisResultProps) => {
+  const spokenAssessment = formatAssessmentForSpeech(diagnosis, patientData);
+
   const getProbabilityColor = (probability: string) => {
     switch (probability.toLowerCase()) {
       case 'alta':
@@ -163,29 +167,38 @@ export const DiagnosisResult = ({ diagnosis, patientData, onReset }: DiagnosisRe
           <CardTitle className="text-lg sm:text-xl">Resumo clínico</CardTitle>
           <CardDescription>{diagnosis.clinicalSummary}</CardDescription>
         </CardHeader>
-        <CardContent className="grid gap-4 lg:grid-cols-2">
-          <div className="rounded-lg border bg-primary-soft/30 p-4">
-            <div className="flex items-center gap-2 mb-3">
-              <FlaskConical className="h-4 w-4 text-primary" />
-              <h3 className="font-semibold">Exames sugeridos</h3>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {diagnosis.suggestedExams.map((exam) => (
-                <Badge key={exam} variant="secondary" className="text-xs">{exam}</Badge>
-              ))}
-            </div>
-          </div>
+        <CardContent className="space-y-4">
+          <VoiceAssistant
+            title="Leitura segura do resultado"
+            description="Ouça uma versão curta da triagem, hipóteses, exames e ações, mantendo o aviso educacional."
+            speechText={spokenAssessment}
+            speakLabel="Ler resultado"
+          />
 
-          <div className="rounded-lg border bg-success-soft/40 p-4">
-            <div className="flex items-center gap-2 mb-3">
-              <ClipboardCheck className="h-4 w-4 text-success" />
-              <h3 className="font-semibold">Ações imediatas</h3>
+          <div className="grid gap-4 lg:grid-cols-2">
+            <div className="rounded-lg border bg-primary-soft/30 p-4">
+              <div className="flex items-center gap-2 mb-3">
+                <FlaskConical className="h-4 w-4 text-primary" />
+                <h3 className="font-semibold">Exames sugeridos</h3>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {diagnosis.suggestedExams.map((exam) => (
+                  <Badge key={exam} variant="secondary" className="text-xs">{exam}</Badge>
+                ))}
+              </div>
             </div>
-            <ul className="space-y-2 text-sm text-muted-foreground list-disc pl-5">
-              {diagnosis.immediateActions.map((action) => (
-                <li key={action}>{action}</li>
-              ))}
-            </ul>
+
+            <div className="rounded-lg border bg-success-soft/40 p-4">
+              <div className="flex items-center gap-2 mb-3">
+                <ClipboardCheck className="h-4 w-4 text-success" />
+                <h3 className="font-semibold">Ações imediatas</h3>
+              </div>
+              <ul className="space-y-2 text-sm text-muted-foreground list-disc pl-5">
+                {diagnosis.immediateActions.map((action) => (
+                  <li key={action}>{action}</li>
+                ))}
+              </ul>
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/src/components/PatientForm.tsx
+++ b/src/components/PatientForm.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { VoiceAssistant } from "@/components/voice/VoiceAssistant";
 import { Loader2, UserCheck, ClipboardList, Stethoscope } from "lucide-react";
 
 interface PatientData {
@@ -100,12 +101,16 @@ export const PatientForm = ({ onSubmit, isAnalyzing, patientData }: PatientFormP
     }
   };
 
+  const appendSymptomsText = (text: string) => {
+    const currentSymptoms = formData.symptoms.trim();
+    const nextSymptoms = currentSymptoms
+      ? `${currentSymptoms}, ${text}`
+      : text;
+    setFormData({ ...formData, symptoms: nextSymptoms });
+  };
+
   const addSymptom = (symptom: string) => {
-    const currentSymptoms = formData.symptoms;
-    const newSymptoms = currentSymptoms 
-      ? `${currentSymptoms}, ${symptom}` 
-      : symptom;
-    setFormData({ ...formData, symptoms: newSymptoms });
+    appendSymptomsText(symptom);
   };
 
   // Mobile detection
@@ -243,6 +248,14 @@ export const PatientForm = ({ onSubmit, isAnalyzing, patientData }: PatientFormP
               className={`text-base min-h-[100px] focus:ring-2 focus:ring-primary/20 ${errors.symptoms ? "border-destructive" : "border-border"}`}
             />
             {errors.symptoms && <p className="text-sm text-destructive">{errors.symptoms}</p>}
+
+            <VoiceAssistant
+              title="Ditado clínico"
+              description="Toque no microfone para ditar sintomas em português. O texto capturado será anexado à anamnese."
+              listenLabel="Falar sintomas"
+              onTranscript={appendSymptomsText}
+              disabled={isAnalyzing}
+            />
             
             {/* Sugestões de Sintomas por Sistema */}
             <div className="space-y-3">

--- a/src/components/voice/VoiceAssistant.tsx
+++ b/src/components/voice/VoiceAssistant.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Mic, MicOff, Volume2, VolumeX } from 'lucide-react';
+
+type SpeechRecognitionConstructor = new () => SpeechRecognition;
+
+interface SpeechRecognitionEventResult {
+  transcript: string;
+}
+
+interface SpeechRecognitionEventLike extends Event {
+  results: ArrayLike<ArrayLike<SpeechRecognitionEventResult>>;
+}
+
+interface SpeechRecognitionErrorEventLike extends Event {
+  error?: string;
+}
+
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null;
+  onend: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+}
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+interface VoiceAssistantProps {
+  title: string;
+  description: string;
+  onTranscript?: (text: string) => void;
+  speechText?: string;
+  listenLabel?: string;
+  stopListenLabel?: string;
+  speakLabel?: string;
+  stopSpeakLabel?: string;
+  disabled?: boolean;
+}
+
+export const VoiceAssistant = ({
+  title,
+  description,
+  onTranscript,
+  speechText,
+  listenLabel = 'Falar',
+  stopListenLabel = 'Parar ditado',
+  speakLabel = 'Ler em voz alta',
+  stopSpeakLabel = 'Parar leitura',
+  disabled = false,
+}: VoiceAssistantProps) => {
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const [isListening, setIsListening] = useState(false);
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const [statusMessage, setStatusMessage] = useState('');
+
+  const recognitionSupported = useMemo(() => {
+    if (typeof window === 'undefined') return false;
+    return Boolean(window.SpeechRecognition || window.webkitSpeechRecognition);
+  }, []);
+
+  const speechSupported = typeof window !== 'undefined' && 'speechSynthesis' in window;
+  const canListen = Boolean(onTranscript) && recognitionSupported && !disabled;
+  const canSpeak = Boolean(speechText) && speechSupported && !disabled;
+
+  useEffect(() => () => {
+    recognitionRef.current?.stop();
+    if (speechSupported) {
+      window.speechSynthesis.cancel();
+    }
+  }, [speechSupported]);
+
+  const startListening = () => {
+    if (!canListen) return;
+
+    const Recognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!Recognition) return;
+
+    const recognition = new Recognition();
+    recognition.continuous = false;
+    recognition.interimResults = false;
+    recognition.lang = 'pt-BR';
+    recognition.onresult = (event) => {
+      const transcript = Array.from(event.results)
+        .map((result) => result[0]?.transcript || '')
+        .join(' ')
+        .trim();
+
+      if (transcript) {
+        onTranscript?.(transcript);
+        setStatusMessage(`Texto capturado: “${transcript}”`);
+      }
+    };
+    recognition.onerror = (event) => {
+      setStatusMessage(`Não consegui ouvir com clareza (${event.error || 'erro de voz'}). Você pode digitar normalmente.`);
+      setIsListening(false);
+    };
+    recognition.onend = () => setIsListening(false);
+
+    recognitionRef.current = recognition;
+    setStatusMessage('Ouvindo em português do Brasil...');
+    setIsListening(true);
+    recognition.start();
+  };
+
+  const stopListening = () => {
+    recognitionRef.current?.stop();
+    setIsListening(false);
+    setStatusMessage('Ditado pausado.');
+  };
+
+  const speak = () => {
+    if (!canSpeak || !speechText) return;
+
+    window.speechSynthesis.cancel();
+    const utterance = new SpeechSynthesisUtterance(speechText);
+    utterance.lang = 'pt-BR';
+    utterance.rate = 0.96;
+    utterance.pitch = 1;
+    utterance.onend = () => setIsSpeaking(false);
+    utterance.onerror = () => {
+      setIsSpeaking(false);
+      setStatusMessage('Não consegui concluir a leitura em voz alta neste navegador.');
+    };
+
+    setIsSpeaking(true);
+    setStatusMessage('Lendo o resumo clínico em voz alta...');
+    window.speechSynthesis.speak(utterance);
+  };
+
+  const stopSpeaking = () => {
+    if (!speechSupported) return;
+    window.speechSynthesis.cancel();
+    setIsSpeaking(false);
+    setStatusMessage('Leitura pausada.');
+  };
+
+  return (
+    <Card className="border-primary/15 bg-primary-soft/20 shadow-sm">
+      <CardContent className="space-y-3 p-4">
+        <div>
+          <p className="text-sm font-semibold text-foreground">{title}</p>
+          <p className="text-xs text-muted-foreground">{description}</p>
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row">
+          {onTranscript && (
+            <Button
+              type="button"
+              variant={isListening ? 'destructive' : 'outline'}
+              onClick={isListening ? stopListening : startListening}
+              disabled={!canListen && !isListening}
+              className="rounded-full"
+            >
+              {isListening ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+              {isListening ? stopListenLabel : listenLabel}
+            </Button>
+          )}
+
+          {speechText && (
+            <Button
+              type="button"
+              variant={isSpeaking ? 'destructive' : 'outline'}
+              onClick={isSpeaking ? stopSpeaking : speak}
+              disabled={!canSpeak && !isSpeaking}
+              className="rounded-full"
+            >
+              {isSpeaking ? <VolumeX className="h-4 w-4" /> : <Volume2 className="h-4 w-4" />}
+              {isSpeaking ? stopSpeakLabel : speakLabel}
+            </Button>
+          )}
+        </div>
+
+        {statusMessage && <p className="text-xs text-muted-foreground">{statusMessage}</p>}
+
+        {onTranscript && !recognitionSupported && (
+          <Alert className="bg-background/80">
+            <AlertTitle>Ditado indisponível</AlertTitle>
+            <AlertDescription>
+              Este navegador não expôs a API de reconhecimento de voz. Você ainda pode preencher a anamnese digitando.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {speechText && !speechSupported && (
+          <Alert className="bg-background/80">
+            <AlertTitle>Leitura indisponível</AlertTitle>
+            <AlertDescription>
+              Este navegador não expôs a API de síntese de voz. O resumo segue disponível em texto.
+            </AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/lib/sessionStore.ts
+++ b/src/lib/sessionStore.ts
@@ -1,0 +1,52 @@
+import { ClinicalAssessment, PatientData } from '@/lib/medicalKnowledge';
+
+const STORAGE_KEY = 'dr-ia:last-clinical-session:v1';
+
+export interface StoredClinicalSession {
+  sessionId: string;
+  createdAt: string;
+  updatedAt: string;
+  patientData: PatientData;
+  diagnosis: ClinicalAssessment;
+}
+
+function canUseLocalStorage() {
+  return typeof window !== 'undefined' && Boolean(window.localStorage);
+}
+
+export function saveClinicalSession(patientData: PatientData, diagnosis: ClinicalAssessment) {
+  if (!canUseLocalStorage()) return;
+
+  const now = new Date().toISOString();
+  const previous = getStoredClinicalSession();
+  const payload: StoredClinicalSession = {
+    sessionId: previous?.sessionId || crypto.randomUUID(),
+    createdAt: previous?.createdAt || now,
+    updatedAt: now,
+    patientData,
+    diagnosis,
+  };
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+export function getStoredClinicalSession(): StoredClinicalSession | null {
+  if (!canUseLocalStorage()) return null;
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as StoredClinicalSession;
+    if (!parsed?.patientData || !parsed?.diagnosis) return null;
+    return parsed;
+  } catch {
+    window.localStorage.removeItem(STORAGE_KEY);
+    return null;
+  }
+}
+
+export function clearStoredClinicalSession() {
+  if (!canUseLocalStorage()) return;
+  window.localStorage.removeItem(STORAGE_KEY);
+}

--- a/src/lib/spokenClinicalFormatter.ts
+++ b/src/lib/spokenClinicalFormatter.ts
@@ -1,0 +1,35 @@
+import { ClinicalAssessment, PatientData } from '@/lib/medicalKnowledge';
+
+const MAX_ITEMS_PER_SECTION = 3;
+
+function joinLimited(items: string[], fallback: string) {
+  const safeItems = items.filter(Boolean).slice(0, MAX_ITEMS_PER_SECTION);
+  if (safeItems.length === 0) return fallback;
+  return safeItems.join('; ');
+}
+
+function buildEmergencyIntro(assessment: ClinicalAssessment) {
+  if (assessment.triageLevel !== 'Emergência') return '';
+
+  return 'Atenção: este caso foi classificado como emergência no simulador educacional. Em uma situação real, procure atendimento imediato e acione o serviço de emergência local. ';
+}
+
+export function formatAssessmentForSpeech(assessment: ClinicalAssessment, patientData?: PatientData) {
+  const topHypotheses = assessment.hypotheses
+    .slice(0, MAX_ITEMS_PER_SECTION)
+    .map((hypothesis) => `${hypothesis.name}, probabilidade ${hypothesis.probability.toLowerCase()}`);
+  const exams = joinLimited(assessment.suggestedExams, 'exames serão definidos conforme avaliação presencial');
+  const actions = joinLimited(assessment.immediateActions, 'reavaliar sinais vitais, complementar anamnese e observar evolução');
+  const symptoms = patientData?.symptoms ? `Sintomas relatados: ${patientData.symptoms}. ` : '';
+
+  return [
+    buildEmergencyIntro(assessment),
+    symptoms,
+    `Triagem: ${assessment.triageLevel}. ${assessment.triageReason}. `,
+    `Resumo clínico: ${assessment.clinicalSummary}. `,
+    `Hipóteses principais: ${topHypotheses.length > 0 ? topHypotheses.join('; ') : 'quadro inespecífico que exige mais dados'}. `,
+    `Exames iniciais sugeridos: ${exams}. `,
+    `Ações imediatas: ${actions}. `,
+    'Aviso: esta é uma simulação educacional e não substitui avaliação médica presencial, preceptor ou protocolo institucional.',
+  ].join('').replace(/\s+/g, ' ').trim();
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,14 +1,23 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { DiagnosisResult } from '@/components/DiagnosisResult';
 import { PatientForm } from '@/components/PatientForm';
 import { SafetyWarning } from '@/components/SafetyWarning';
 import { analyzeClinicalCase } from '@/lib/aiClient';
+import { clearStoredClinicalSession, getStoredClinicalSession, saveClinicalSession } from '@/lib/sessionStore';
 import { ClinicalAssessment, PatientData } from '@/lib/medicalKnowledge';
 
 const Index = () => {
   const [patientData, setPatientData] = useState<PatientData | null>(null);
   const [diagnosis, setDiagnosis] = useState<ClinicalAssessment | null>(null);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
+
+  useEffect(() => {
+    const storedSession = getStoredClinicalSession();
+    if (!storedSession) return;
+
+    setPatientData(storedSession.patientData);
+    setDiagnosis(storedSession.diagnosis);
+  }, []);
 
   const handleFormSubmit = async (data: PatientData) => {
     setIsAnalyzing(true);
@@ -20,12 +29,14 @@ const Index = () => {
         objective: 'simulacao-clinica',
       });
       setDiagnosis(nextDiagnosis);
+      saveClinicalSession(data, nextDiagnosis);
     } finally {
       setIsAnalyzing(false);
     }
   };
 
   const handleReset = () => {
+    clearStoredClinicalSession();
     setPatientData(null);
     setDiagnosis(null);
   };


### PR DESCRIPTION
### Motivation
- Add native voice input and text-to-speech to improve accessibility and faster data entry during anamnese.
- Provide a concise, safe spoken rendering of clinical assessments for auditory review.
- Persist the last clinical session locally so users can resume or review the last simulation.

### Description
- Introduces a new `VoiceAssistant` component (`src/components/voice/VoiceAssistant.tsx`) that uses Web Speech APIs for dictation and speech synthesis with status/error handling and Portuguese (`pt-BR`) defaults.
- Adds `formatAssessmentForSpeech` (`src/lib/spokenClinicalFormatter.ts`) to produce a compact, safety-aware spoken string from `ClinicalAssessment` and optional `PatientData`.
- Adds local session persistence helpers in `src/lib/sessionStore.ts` with `saveClinicalSession`, `getStoredClinicalSession`, and `clearStoredClinicalSession` using `localStorage` and a stable storage key.
- Integrates voice features and persistence into the UI: `PatientForm` now supports voice dictation via `VoiceAssistant` and symptom appending, `DiagnosisResult` includes a `VoiceAssistant` to read results using `formatAssessmentForSpeech`, and `Index` restores/saves/clears sessions via the session store; also minor Card layout adjustments in `DiagnosisResult`.

### Testing
- Ran TypeScript compile check with `tsc --noEmit`, which passed without type errors.
- Executed a local production build with `npm run build` to validate bundling and JSX output, which completed successfully.
- Ran linting via `npm run lint` to validate code style and imports, which returned no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d90aa5924832d8605ce0156777127)