### PR TITLE
Adicionar carregador de conhecimento clínico versionado

### DIFF
--- a/data/clinical-knowledge/conditions.v1.json
+++ b/data/clinical-knowledge/conditions.v1.json
@@ -1,0 +1,620 @@
+{
+  "version": "1.0.0",
+  "status": "published",
+  "generatedFrom": "src/lib/medicalKnowledge.ts",
+  "generatedAt": "2026-06-01",
+  "conditions": [
+    {
+      "id": "sindrome-coronariana-aguda",
+      "version": 1,
+      "status": "published",
+      "lastReviewedAt": "2026-06-01",
+      "name": "Síndrome Coronariana Aguda",
+      "icd10": "I20-I25",
+      "category": "cardiovascular",
+      "commonSymptoms": [
+        "dor torácica",
+        "dor no peito",
+        "dispneia",
+        "sudorese",
+        "náusea"
+      ],
+      "riskFactors": [
+        "idade > 40 anos",
+        "diabetes",
+        "hipertensão",
+        "tabagismo",
+        "dislipidemia"
+      ],
+      "ageGroups": [
+        "adulto",
+        "idoso"
+      ],
+      "genderPreference": "masculino",
+      "urgencyLevel": "emergencia",
+      "treatments": [
+        "Antiagregação plaquetária conforme protocolo",
+        "Estatina de alta potência conforme protocolo",
+        "Controle de sintomas e monitorização",
+        "Avaliação de reperfusão pela equipe"
+      ],
+      "differentials": [
+        "Pericardite",
+        "Embolia pulmonar",
+        "Pneumotórax",
+        "Dissecção aórtica"
+      ],
+      "redFlags": [
+        "dor em aperto/peso",
+        "irradiação para braço esquerdo",
+        "sudorese profusa"
+      ],
+      "clinicalPearls": [
+        "ECG em até 10min",
+        "Troponinas seriadas",
+        "Score TIMI/GRACE"
+      ],
+      "recommendedExams": [
+        "ECG",
+        "Troponina seriada",
+        "RX de tórax",
+        "Monitorização cardíaca"
+      ],
+      "durationProfile": [
+        "hiperagudo",
+        "agudo"
+      ]
+    },
+    {
+      "id": "insuficiencia-cardiaca-aguda",
+      "version": 1,
+      "status": "published",
+      "lastReviewedAt": "2026-06-01",
+      "name": "Insuficiência Cardíaca Aguda",
+      "icd10": "I50",
+      "category": "cardiovascular",
+      "commonSymptoms": [
+        "dispneia",
+        "edema",
+        "ortopneia",
+        "dispneia paroxística noturna"
+      ],
+      "riskFactors": [
+        "hipertensão",
+        "diabetes",
+        "cardiopatia isquêmica",
+        "idade > 65"
+      ],
+      "ageGroups": [
+        "adulto",
+        "idoso"
+      ],
+      "urgencyLevel": "alta",
+      "treatments": [
+        "Diurético de alça conforme protocolo",
+        "Vasodilatador/inibidor do SRAA conforme protocolo",
+        "Ajuste de terapia de insuficiência cardíaca"
+      ],
+      "differentials": [
+        "Pneumonia",
+        "DPOC",
+        "Embolia pulmonar"
+      ],
+      "redFlags": [
+        "sat O2 < 90%",
+        "crepitantes bibasais",
+        "B3 audível"
+      ],
+      "clinicalPearls": [
+        "BNP/NT-proBNP",
+        "Ecocardiograma",
+        "Classificação NYHA"
+      ],
+      "recommendedExams": [
+        "BNP/NT-proBNP",
+        "Ecocardiograma",
+        "RX de tórax",
+        "Função renal"
+      ],
+      "durationProfile": [
+        "agudo",
+        "subagudo"
+      ]
+    },
+    {
+      "id": "pneumonia-adquirida-na-comunidade",
+      "version": 1,
+      "status": "published",
+      "lastReviewedAt": "2026-06-01",
+      "name": "Pneumonia Adquirida na Comunidade",
+      "icd10": "J18",
+      "category": "respiratorio",
+      "commonSymptoms": [
+        "febre",
+        "tosse produtiva",
+        "dispneia",
+        "dor pleurítica"
+      ],
+      "riskFactors": [
+        "idade > 65",
+        "DPOC",
+        "diabetes",
+        "etilismo",
+        "tabagismo"
+      ],
+      "ageGroups": [
+        "adulto",
+        "idoso"
+      ],
+      "urgencyLevel": "moderada",
+      "treatments": [
+        "Antibioticoterapia empírica guiada por gravidade e perfil local",
+        "Suporte respiratório conforme necessidade",
+        "Reavaliação clínica seriada"
+      ],
+      "differentials": [
+        "Bronquite aguda",
+        "COVID-19",
+        "Tuberculose"
+      ],
+      "redFlags": [
+        "sat O2 < 90%",
+        "confusão mental",
+        "hipotensão"
+      ],
+      "clinicalPearls": [
+        "Score CURB-65",
+        "RX tórax",
+        "Procalcitonina se disponível"
+      ],
+      "recommendedExams": [
+        "RX de tórax",
+        "Hemograma",
+        "Oximetria",
+        "Score CURB-65"
+      ],
+      "durationProfile": [
+        "agudo",
+        "subagudo"
+      ]
+    },
+    {
+      "id": "asma-agudizada",
+      "version": 1,
+      "status": "published",
+      "lastReviewedAt": "2026-06-01",
+      "name": "Asma Agudizada",
+      "icd10": "J45",
+      "category": "respiratorio",
+      "commonSymptoms": [
+        "dispneia",
+        "sibilos",
+        "tosse seca",
+        "opressão torácica"
+      ],
+      "riskFactors": [
+        "história pessoal/familiar",
+        "alergens",
+        "infecções respiratórias"
+      ],
+      "ageGroups": [
+        "crianca",
+        "adolescente",
+        "adulto"
+      ],
+      "urgencyLevel": "moderada",
+      "treatments": [
+        "Broncodilatador de resgate conforme protocolo",
+        "Corticoterapia conforme gravidade",
+        "Monitorização de resposta clínica"
+      ],
+      "differentials": [
+        "DPOC",
+        "Pneumonia",
+        "Pneumotórax"
+      ],
+      "redFlags": [
+        "uso de musculatura acessória",
+        "cianose",
+        "silêncio auscultatório"
+      ],
+      "clinicalPearls": [
+        "Peak flow",
+        "Saturação O2",
+        "Resposta ao broncodilatador"
+      ],
+      "recommendedExams": [
+        "Oximetria",
+        "Peak flow",
+        "Avaliação clínica seriada"
+      ],
+      "durationProfile": [
+        "hiperagudo",
+        "agudo"
+      ]
+    },
+    {
+      "id": "apendicite-aguda",
+      "version": 1,
+      "status": "published",
+      "lastReviewedAt": "2026-06-01",
+      "name": "Apendicite Aguda",
+      "icd10": "K35",
+      "category": "gastrointestinal",
+      "commonSymptoms": [
+        "dor abdominal",
+        "náusea",
+        "vômito",
+        "febre"
+      ],
+      "riskFactors": [
+        "idade 10-30 anos",
+        "sexo masculino"
+      ],
+      "ageGroups": [
+        "crianca",
+        "adolescente",
+        "adulto"
+      ],
+      "urgencyLevel": "alta",
+      "treatments": [
+        "Analgesia e hidratação conforme protocolo",
+        "Antibioticoprofilaxia perioperatória conforme protocolo",
+        "Avaliação cirúrgica imediata"
+      ],
+      "differentials": [
+        "Gastroenterite",
+        "DIP",
+        "Litíase urinária",
+        "Gravidez ectópica"
+      ],
+      "redFlags": [
+        "sinal de Blumberg",
+        "migração da dor",
+        "leucocitose com desvio"
+      ],
+      "clinicalPearls": [
+        "Score de Alvarado",
+        "TC abdome se dúvida",
+        "Cirurgia urgente"
+      ],
+      "recommendedExams": [
+        "Hemograma",
+        "PCR",
+        "USG/TC de abdome",
+        "Score de Alvarado"
+      ],
+      "durationProfile": [
+        "agudo"
+      ]
+    },
+    {
+      "id": "gastroenterite-aguda",
+      "version": 1,
+      "status": "published",
+      "lastReviewedAt": "2026-06-01",
+      "name": "Gastroenterite Aguda",
+      "icd10": "K59.1",
+      "category": "gastrointestinal",
+      "commonSymptoms": [
+        "diarreia",
+        "vômito",
+        "dor abdominal",
+        "febre"
+      ],
+      "riskFactors": [
+        "alimentos contaminados",
+        "viagens",
+        "contato com doentes"
+      ],
+      "ageGroups": [
+        "crianca",
+        "adulto"
+      ],
+      "urgencyLevel": "baixa",
+      "treatments": [
+        "Soro de reidratação oral",
+        "Probióticos",
+        "Sintomáticos"
+      ],
+      "differentials": [
+        "Apendicite",
+        "DII",
+        "Intoxicação alimentar"
+      ],
+      "redFlags": [
+        "desidratação severa",
+        "sangue nas fezes",
+        "febre alta"
+      ],
+      "clinicalPearls": [
+        "Hidratação é fundamental",
+        "Evitar antidiarreicos se febre"
+      ],
+      "recommendedExams": [
+        "Avaliação de hidratação",
+        "Eletrólitos se grave",
+        "Coprocultura se indicado"
+      ],
+      "durationProfile": [
+        "agudo"
+      ]
+    },
+    {
+      "id": "cefaleia-tensional",
+      "version": 1,
+      "status": "published",
+      "lastReviewedAt": "2026-06-01",
+      "name": "Cefaleia Tensional",
+      "icd10": "G44.2",
+      "category": "neurologico",
+      "commonSymptoms": [
+        "cefaleia",
+        "dor de cabeça",
+        "tensão cervical"
+      ],
+      "riskFactors": [
+        "estresse",
+        "ansiedade",
+        "má postura",
+        "sono inadequado"
+      ],
+      "ageGroups": [
+        "adolescente",
+        "adulto"
+      ],
+      "urgencyLevel": "baixa",
+      "treatments": [
+        "Analgésico simples conforme protocolo",
+        "Medidas não farmacológicas (sono, postura, manejo de estresse)",
+        "Acompanhamento ambulatorial"
+      ],
+      "differentials": [
+        "Enxaqueca",
+        "Cefaleia em salvas",
+        "Hipertensão intracraniana"
+      ],
+      "redFlags": [
+        "início súbito",
+        "febre + rigidez nucal",
+        "alterações neurológicas"
+      ],
+      "clinicalPearls": [
+        "História é fundamental",
+        "Sinais de alarme",
+        "Diário da cefaleia"
+      ],
+      "recommendedExams": [
+        "Exame neurológico",
+        "Neuroimagem se sinais de alarme"
+      ],
+      "durationProfile": [
+        "subagudo",
+        "cronico"
+      ]
+    },
+    {
+      "id": "enxaqueca-com-aura",
+      "version": 1,
+      "status": "published",
+      "lastReviewedAt": "2026-06-01",
+      "name": "Enxaqueca com Aura",
+      "icd10": "G43.1",
+      "category": "neurologico",
+      "commonSymptoms": [
+        "enxaqueca",
+        "cefaleia",
+        "dor de cabeça",
+        "aura",
+        "fotofobia",
+        "náusea"
+      ],
+      "riskFactors": [
+        "história pessoal/familiar",
+        "gatilhos alimentares",
+        "privação de sono",
+        "estresse"
+      ],
+      "ageGroups": [
+        "adolescente",
+        "adulto"
+      ],
+      "urgencyLevel": "moderada",
+      "treatments": [
+        "Analgésicos e antieméticos conforme protocolo institucional",
+        "Hidratação e ambiente com menor estímulo luminoso",
+        "Reavaliação clínica e prevenção de gatilhos"
+      ],
+      "differentials": [
+        "Cefaleia tensional",
+        "Cefaleia secundária",
+        "AVC (quando sinais focais)"
+      ],
+      "redFlags": [
+        "déficit neurológico persistente",
+        "cefaleia súbita em thunderclap",
+        "alteração do nível de consciência"
+      ],
+      "clinicalPearls": [
+        "Aura visual transitória e fotofobia favorecem enxaqueca com aura",
+        "Sempre excluir causas secundárias quando houver red flags"
+      ],
+      "recommendedExams": [
+        "Exame neurológico",
+        "Neuroimagem se sinais de alarme"
+      ],
+      "durationProfile": [
+        "agudo",
+        "subagudo",
+        "cronico"
+      ]
+    },
+    {
+      "id": "acidente-vascular-cerebral",
+      "version": 1,
+      "status": "published",
+      "lastReviewedAt": "2026-06-01",
+      "name": "Acidente Vascular Cerebral",
+      "icd10": "I64",
+      "category": "neurologico",
+      "commonSymptoms": [
+        "hemiparesia",
+        "afasia",
+        "alteração consciência",
+        "cefaleia súbita"
+      ],
+      "riskFactors": [
+        "hipertensão",
+        "diabetes",
+        "FA",
+        "idade > 55",
+        "tabagismo"
+      ],
+      "ageGroups": [
+        "adulto",
+        "idoso"
+      ],
+      "urgencyLevel": "emergencia",
+      "treatments": [
+        "Protocolo AVC agudo e monitorização neurológica",
+        "Terapia antitrombótica conforme imagem e protocolo",
+        "Avaliação para reperfusão em janela terapêutica"
+      ],
+      "differentials": [
+        "Hipoglicemia",
+        "Enxaqueca com aura",
+        "Convulsão"
+      ],
+      "redFlags": [
+        "déficit focal súbito",
+        "NIHSS > 4",
+        "< 4,5h de início"
+      ],
+      "clinicalPearls": [
+        "Janela terapêutica",
+        "TC crânio urgente",
+        "Scale NIHSS/ABCD2"
+      ],
+      "recommendedExams": [
+        "TC de crânio",
+        "Glicemia capilar",
+        "NIHSS",
+        "ECG"
+      ],
+      "durationProfile": [
+        "hiperagudo",
+        "agudo"
+      ]
+    },
+    {
+      "id": "infeccao-do-trato-urinario",
+      "version": 1,
+      "status": "published",
+      "lastReviewedAt": "2026-06-01",
+      "name": "Infecção do Trato Urinário",
+      "icd10": "N39.0",
+      "category": "genitourinario",
+      "commonSymptoms": [
+        "disúria",
+        "polaciúria",
+        "urgência miccional",
+        "dor suprapúbica"
+      ],
+      "riskFactors": [
+        "sexo feminino",
+        "atividade sexual",
+        "diabetes",
+        "gravidez"
+      ],
+      "ageGroups": [
+        "adulto"
+      ],
+      "genderPreference": "feminino",
+      "urgencyLevel": "baixa",
+      "treatments": [
+        "Antibiótico de primeira linha conforme diretriz local",
+        "Hidratação e analgesia conforme necessidade",
+        "Reavaliação com cultura quando indicado"
+      ],
+      "differentials": [
+        "Vaginite",
+        "Uretrite",
+        "Pielonefrite"
+      ],
+      "redFlags": [
+        "febre + dor lombar",
+        "náuseas/vômitos",
+        "hematúria macroscópica"
+      ],
+      "clinicalPearls": [
+        "EAS + urocultura",
+        "Tratamento empírico inicial",
+        "Seguimento clínico"
+      ],
+      "recommendedExams": [
+        "EAS",
+        "Urocultura",
+        "Função renal se grave"
+      ],
+      "durationProfile": [
+        "agudo",
+        "subagudo"
+      ]
+    },
+    {
+      "id": "covid-19",
+      "version": 1,
+      "status": "published",
+      "lastReviewedAt": "2026-06-01",
+      "name": "COVID-19",
+      "icd10": "U07.1",
+      "category": "infeccioso",
+      "commonSymptoms": [
+        "febre",
+        "tosse seca",
+        "fadiga",
+        "anosmia",
+        "dispneia"
+      ],
+      "riskFactors": [
+        "idade > 60",
+        "comorbidades",
+        "imunossupressão",
+        "obesidade"
+      ],
+      "ageGroups": [
+        "adulto",
+        "idoso"
+      ],
+      "urgencyLevel": "moderada",
+      "treatments": [
+        "Sintomáticos",
+        "Corticóides se O2 < 94%",
+        "Anticoagulação"
+      ],
+      "differentials": [
+        "Influenza",
+        "Pneumonia bacteriana",
+        "Outras viroses"
+      ],
+      "redFlags": [
+        "sat O2 < 94%",
+        "dispneia progressiva",
+        "confusão mental"
+      ],
+      "clinicalPearls": [
+        "RT-PCR",
+        "D-dímero elevado",
+        "Isolamento necessário"
+      ],
+      "recommendedExams": [
+        "Teste antigênico/RT-PCR",
+        "Oximetria",
+        "RX/TC se grave"
+      ],
+      "durationProfile": [
+        "agudo"
+      ]
+    }
+  ]
+}

--- a/data/clinical-knowledge/sources.v1.json
+++ b/data/clinical-knowledge/sources.v1.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "generatedAt": "2026-06-01",
+  "sources": [
+    {
+      "id": "ncbi-eutilities",
+      "sourceType": "pubmed",
+      "title": "NCBI E-utilities API",
+      "url": "https://www.ncbi.nlm.nih.gov/books/NBK25501/",
+      "license": "metadata/API reference; verify each linked record license before ingesting text",
+      "publisher": "National Center for Biotechnology Information",
+      "year": 2026,
+      "retrievedAt": "2026-06-01"
+    },
+    {
+      "id": "who-icd11-api",
+      "sourceType": "icd",
+      "title": "WHO ICD-11 API",
+      "url": "https://icd.who.int/icdapi",
+      "license": "WHO API terms; use for identifiers and permitted metadata only",
+      "publisher": "World Health Organization",
+      "year": 2026,
+      "retrievedAt": "2026-06-01"
+    }
+  ]
+}

--- a/docs/CLINICAL_KNOWLEDGE_ARCHITECTURE.md
+++ b/docs/CLINICAL_KNOWLEDGE_ARCHITECTURE.md
@@ -1,0 +1,50 @@
+# Arquitetura de conhecimento clínico
+
+Este projeto mantém uma arquitetura em camadas para não depender 100% de banco, rede ou IA durante a análise local.
+
+## Camada 1 — base local segura
+
+- `src/lib/medicalKnowledge.ts` continua contendo `FALLBACK_MEDICAL_CONDITIONS` como core seguro.
+- `buildLocalAssessment` e `findMatchingConditions` continuam síncronos e defensivos.
+- Se o pacote JSON versionado estiver inválido, o loader retorna automaticamente o fallback TypeScript.
+
+## Camada 2 — JSON clínico versionado
+
+A primeira etapa implementada é a separação dos dados clínicos carregáveis:
+
+- `data/clinical-knowledge/conditions.v1.json`: condições clínicas publicadas/revisadas.
+- `data/clinical-knowledge/sources.v1.json`: catálogo inicial de fontes permitidas para enriquecimento futuro.
+- `src/lib/clinicalKnowledgeSchema.ts`: schema Zod rígido para validar condições, status, versão e revisão.
+- `scripts/validate-clinical-knowledge.ts`: validação CLI para CI/local.
+
+Status aceitos para condições:
+
+- `draft`: rascunho, não entra no runtime ativo.
+- `reviewed`: revisado, pode entrar no runtime ativo.
+- `published`: publicado, pode entrar no runtime ativo.
+- `deprecated`: obsoleto, não entra no runtime ativo.
+
+## Camada 3 — próxima fase, ainda não implementada
+
+A evolução recomendada continua sendo incremental:
+
+1. Criar tabelas Postgres para `clinical_conditions`, sintomas, red flags, diferenciais, exames, fontes e assertions clínicas.
+2. Semear o banco a partir de `conditions.v1.json`.
+3. Manter carregamento em cascata: banco publicado → JSON versionado → fallback TypeScript.
+4. Adicionar busca estruturada em SQL antes de qualquer busca vetorial.
+5. Adicionar pgvector apenas para explicações e trechos curtos com fonte, não para decisão clínica crítica.
+
+## Workers futuros
+
+Workers de PubMed/ICD/guidelines devem alimentar uma base curada, não responder diretamente ao usuário:
+
+```text
+Source Discovery → Ingestion Queue → Extractor → Normalizer → Safety Validator → Human Review → Published Knowledge DB
+```
+
+Regras mínimas para essa fase:
+
+- Não copiar texto sem licença explícita.
+- Não publicar automaticamente itens de alto risco.
+- Não permitir dose explícita em conteúdo gerado para o usuário.
+- Versionar e permitir rollback de toda publicação clínica.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "safety:coherence:guard": "tsx scripts/clinical-coherence-guard.ts",
     "safety:generate:10k": "tsx scripts/generate-disease-possibilities.ts",
     "preview": "vite preview",
-    "start:server": "npx tsx backend/server.ts"
+    "start:server": "npx tsx backend/server.ts",
+    "knowledge:validate": "tsx scripts/validate-clinical-knowledge.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/validate-clinical-knowledge.ts
+++ b/scripts/validate-clinical-knowledge.ts
@@ -1,0 +1,30 @@
+import conditionsBundle from '../data/clinical-knowledge/conditions.v1.json';
+import { clinicalKnowledgeBundleSchema } from '../src/lib/clinicalKnowledgeSchema';
+
+const parsed = clinicalKnowledgeBundleSchema.safeParse(conditionsBundle);
+
+if (!parsed.success) {
+  console.error('Clinical knowledge JSON is invalid:');
+  for (const issue of parsed.error.issues) {
+    console.error(`- ${issue.path.join('.')}: ${issue.message}`);
+  }
+  process.exit(1);
+}
+
+const conditionNames = new Set<string>();
+const conditionIds = new Set<string>();
+
+for (const condition of parsed.data.conditions) {
+  if (conditionNames.has(condition.name)) {
+    console.error(`Duplicate clinical condition name: ${condition.name}`);
+    process.exit(1);
+  }
+  if (conditionIds.has(condition.id)) {
+    console.error(`Duplicate clinical condition id: ${condition.id}`);
+    process.exit(1);
+  }
+  conditionNames.add(condition.name);
+  conditionIds.add(condition.id);
+}
+
+console.log(`Clinical knowledge OK: ${parsed.data.conditions.length} conditions in ${parsed.data.version}.`);

--- a/src/lib/clinicalKnowledgeSchema.test.ts
+++ b/src/lib/clinicalKnowledgeSchema.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { CLINICAL_KNOWLEDGE_FALLBACK_CONDITIONS, MEDICAL_CONDITIONS } from './medicalKnowledge';
+import { loadClinicalKnowledgeFromJson } from './clinicalKnowledgeSchema';
+
+describe('clinical knowledge loader', () => {
+  it('carrega condições publicadas a partir do JSON versionado', () => {
+    expect(MEDICAL_CONDITIONS.length).toBeGreaterThan(0);
+    expect(MEDICAL_CONDITIONS[0]).toMatchObject({
+      id: expect.any(String),
+      version: expect.any(Number),
+      status: expect.stringMatching(/published|reviewed/),
+      lastReviewedAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+    });
+  });
+
+  it('preserva fallback TypeScript quando o bundle JSON é inválido', () => {
+    const result = loadClinicalKnowledgeFromJson({ conditions: [] }, CLINICAL_KNOWLEDGE_FALLBACK_CONDITIONS);
+
+    expect(result.source).toBe('fallback');
+    expect(result.conditions).toBe(CLINICAL_KNOWLEDGE_FALLBACK_CONDITIONS);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('não publica itens em draft/deprecated no carregamento ativo', () => {
+    const result = loadClinicalKnowledgeFromJson(
+      {
+        version: 'test',
+        status: 'reviewed',
+        generatedAt: '2026-06-01',
+        conditions: [
+          {
+            id: 'cond-draft',
+            name: 'Condição Draft',
+            category: 'teste',
+            commonSymptoms: ['sintoma'],
+            urgencyLevel: 'baixa',
+            treatments: ['conduta educacional'],
+            version: 1,
+            status: 'draft',
+            lastReviewedAt: '2026-06-01',
+          },
+          {
+            id: 'cond-reviewed',
+            name: 'Condição Revisada',
+            category: 'teste',
+            commonSymptoms: ['sintoma'],
+            urgencyLevel: 'baixa',
+            treatments: ['conduta educacional'],
+            version: 1,
+            status: 'reviewed',
+            lastReviewedAt: '2026-06-01',
+          },
+        ],
+      },
+      CLINICAL_KNOWLEDGE_FALLBACK_CONDITIONS,
+    );
+
+    expect(result.source).toBe('json');
+    expect(result.conditions).toHaveLength(1);
+    expect(result.conditions[0].name).toBe('Condição Revisada');
+  });
+});

--- a/src/lib/clinicalKnowledgeSchema.ts
+++ b/src/lib/clinicalKnowledgeSchema.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod';
+
+import clinicalConditionsJson from '../../data/clinical-knowledge/conditions.v1.json';
+import type { MedicalCondition } from './medicalKnowledge';
+
+const urgencyLevelSchema = z.enum(['baixa', 'moderada', 'alta', 'emergencia']);
+const reviewStatusSchema = z.enum(['draft', 'reviewed', 'published', 'deprecated']);
+const durationProfileSchema = z.enum(['hiperagudo', 'agudo', 'subagudo', 'cronico']);
+
+export const clinicalConditionSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  icd10: z.string().min(1).optional(),
+  icd11: z.string().min(1).optional(),
+  category: z.string().min(1),
+  commonSymptoms: z.array(z.string().min(1)).min(1),
+  riskFactors: z.array(z.string().min(1)).default([]),
+  ageGroups: z.array(z.string().min(1)).default([]),
+  genderPreference: z.enum(['masculino', 'feminino', 'both']).optional(),
+  urgencyLevel: urgencyLevelSchema,
+  treatments: z.array(z.string().min(1)).min(1),
+  differentials: z.array(z.string().min(1)).default([]),
+  redFlags: z.array(z.string().min(1)).default([]),
+  clinicalPearls: z.array(z.string().min(1)).default([]),
+  recommendedExams: z.array(z.string().min(1)).default([]),
+  durationProfile: z.array(durationProfileSchema).optional(),
+  version: z.number().int().positive(),
+  status: reviewStatusSchema,
+  lastReviewedAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+
+export const clinicalKnowledgeBundleSchema = z.object({
+  version: z.string().min(1),
+  status: z.enum(['draft', 'reviewed', 'published']),
+  generatedFrom: z.string().min(1).optional(),
+  generatedAt: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  conditions: z.array(clinicalConditionSchema).min(1),
+});
+
+export type ClinicalKnowledgeCondition = z.infer<typeof clinicalConditionSchema>;
+export type ClinicalKnowledgeBundle = z.infer<typeof clinicalKnowledgeBundleSchema>;
+
+export interface ClinicalKnowledgeLoadResult {
+  conditions: MedicalCondition[];
+  source: 'json' | 'fallback';
+  warnings: string[];
+}
+
+function toMedicalCondition(condition: ClinicalKnowledgeCondition): MedicalCondition {
+  return {
+    id: condition.id,
+    name: condition.name,
+    icd10: condition.icd10,
+    icd11: condition.icd11,
+    category: condition.category,
+    commonSymptoms: condition.commonSymptoms,
+    riskFactors: condition.riskFactors,
+    ageGroups: condition.ageGroups,
+    genderPreference: condition.genderPreference,
+    urgencyLevel: condition.urgencyLevel,
+    treatments: condition.treatments,
+    differentials: condition.differentials,
+    redFlags: condition.redFlags,
+    clinicalPearls: condition.clinicalPearls,
+    recommendedExams: condition.recommendedExams,
+    durationProfile: condition.durationProfile,
+    version: condition.version,
+    status: condition.status,
+    lastReviewedAt: condition.lastReviewedAt,
+  };
+}
+
+export function loadClinicalKnowledgeFromJson(
+  rawBundle: unknown,
+  fallbackConditions: MedicalCondition[],
+): ClinicalKnowledgeLoadResult {
+  const parsed = clinicalKnowledgeBundleSchema.safeParse(rawBundle);
+
+  if (!parsed.success) {
+    return {
+      conditions: fallbackConditions,
+      source: 'fallback',
+      warnings: parsed.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`),
+    };
+  }
+
+  const publishedConditions = parsed.data.conditions
+    .filter((condition) => condition.status === 'published' || condition.status === 'reviewed')
+    .map(toMedicalCondition);
+
+  if (publishedConditions.length === 0) {
+    return {
+      conditions: fallbackConditions,
+      source: 'fallback',
+      warnings: ['Nenhuma condição publicada/revisada encontrada no JSON clínico.'],
+    };
+  }
+
+  return {
+    conditions: publishedConditions,
+    source: 'json',
+    warnings: [],
+  };
+}
+
+export function loadPublishedMedicalConditions(fallbackConditions: MedicalCondition[]) {
+  return loadClinicalKnowledgeFromJson(clinicalConditionsJson, fallbackConditions).conditions;
+}

--- a/src/lib/medicalKnowledge.ts
+++ b/src/lib/medicalKnowledge.ts
@@ -1,6 +1,10 @@
+import { loadPublishedMedicalConditions } from './clinicalKnowledgeSchema';
+
 export interface MedicalCondition {
+  id?: string;
   name: string;
   icd10?: string;
+  icd11?: string;
   category: string;
   commonSymptoms: string[];
   riskFactors: string[];
@@ -13,6 +17,9 @@ export interface MedicalCondition {
   clinicalPearls: string[];
   recommendedExams: string[];
   durationProfile?: Array<'hiperagudo' | 'agudo' | 'subagudo' | 'cronico'>;
+  version?: number;
+  status?: 'draft' | 'reviewed' | 'published' | 'deprecated';
+  lastReviewedAt?: string;
 }
 
 export interface PatientData {
@@ -146,7 +153,7 @@ const CONDITION_MEDICATION_OPTIONS: Record<string, Array<{ name: string; why: st
   ],
 };
 
-export const MEDICAL_CONDITIONS: MedicalCondition[] = [
+const FALLBACK_MEDICAL_CONDITIONS: MedicalCondition[] = [
   {
     name: 'Síndrome Coronariana Aguda',
     icd10: 'I20-I25',
@@ -315,6 +322,10 @@ export const MEDICAL_CONDITIONS: MedicalCondition[] = [
     durationProfile: ['agudo'],
   },
 ];
+
+export const MEDICAL_CONDITIONS: MedicalCondition[] = loadPublishedMedicalConditions(FALLBACK_MEDICAL_CONDITIONS);
+
+export const CLINICAL_KNOWLEDGE_FALLBACK_CONDITIONS: MedicalCondition[] = FALLBACK_MEDICAL_CONDITIONS;
 
 export const CLINICAL_SCALES = {
   CURB65: {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,6 +13,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "resolveJsonModule": true,
 
     /* Linting */
     "strict": false,
@@ -26,5 +27,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "data/**/*.json"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -8,6 +8,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,


### PR DESCRIPTION
### Motivation

- Garantir que a aplicação nunca dependa 100% de código hardcoded e manter `src/lib/medicalKnowledge.ts` como fallback seguro. 
- Permitir um caminho incremental para transformar o catálogo clínico atual em dados versionados e validáveis fora do código. 
- Publicar apenas conteúdo clinicamente revisado/`published` e evitar que bundles inválidos ou incompletos substituam o fallback local. 
- Preparar a base (JSON + schema + validação) para futuras fases com banco, vetores e workers sem implementar essas fases agora.

### Description

- Adiciona o bundle versionado `data/clinical-knowledge/conditions.v1.json` e o catálogo de fontes `data/clinical-knowledge/sources.v1.json`. 
- Cria `src/lib/clinicalKnowledgeSchema.ts` com schemas Zod e a função `loadPublishedMedicalConditions` que valida o bundle e mapeia apenas itens `published`/`reviewed`. 
- Mantém a base TypeScript como `FALLBACK_MEDICAL_CONDITIONS` em `src/lib/medicalKnowledge.ts` e passa `MEDICAL_CONDITIONS` a carregar via loader com fallback automático; adiciona `CLINICAL_KNOWLEDGE_FALLBACK_CONDITIONS`. 
- Adiciona script de validação `scripts/validate-clinical-knowledge.ts`, testes `src/lib/clinicalKnowledgeSchema.test.ts`, documentação `docs/CLINICAL_KNOWLEDGE_ARCHITECTURE.md`, atualização de `tsconfig` para `resolveJsonModule` e um script npm `knowledge:validate` no `package.json`.

### Testing

- Rodei `npm run knowledge:validate` para validar o JSON clínico e a checagem retornou sucesso. 
- Rodei `npm test` e os testes passaram (todas as suítes executadas; resumo: 40 passed). 
- Rodei `npm run lint` e `npm run build` com sucesso para garantir que as mudanças compilam e respeitam linting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1de44f9af4832db7161bc2a93163c4)