### PR TITLE
Add educational Evidence Agent and overhaul clinical UI with new endpoints

### DIFF
--- a/backend/evidenceAgent.ts
+++ b/backend/evidenceAgent.ts
@@ -1,0 +1,438 @@
+import crypto from 'node:crypto';
+import { promises as fs } from 'node:fs';
+
+export type EvidenceSourceKind = 'guideline' | 'public-health' | 'reference' | 'repository' | 'internal-kb';
+
+export interface EvidenceSource {
+  id: string;
+  name: string;
+  url: string;
+  kind: EvidenceSourceKind;
+  topics: string[];
+  language: 'pt-BR' | 'en';
+  refreshHours: number;
+}
+
+export interface EvidenceRecord {
+  id: string;
+  title: string;
+  sourceId: string;
+  sourceName: string;
+  sourceUrl: string;
+  topics: string[];
+  summary: string;
+  content: string;
+  retrievedAt: string;
+  updatedAt?: string;
+  confidence: 'seed' | 'internal-generated' | 'remote-refreshed';
+}
+
+export interface EvidenceSearchResult extends EvidenceRecord {
+  score: number;
+  matchedTerms: string[];
+}
+
+interface EvidenceSearchDocument {
+  record: EvidenceRecord;
+  haystack: string;
+  titleText: string;
+}
+
+const EVIDENCE_STORE_FILE = process.env.EVIDENCE_STORE_FILE || '/tmp/clinic-intuition-evidence-kb.json';
+const MAX_REMOTE_TEXT_CHARS = 18_000;
+const MAX_RECORDS_PER_REFRESH = 12;
+
+export const evidenceSources: EvidenceSource[] = [
+  {
+    id: 'internal-massive-kb',
+    name: 'Base interna massiva educacional',
+    url: 'internal://clinical-kb',
+    kind: 'internal-kb',
+    topics: ['base interna', 'educacional', 'triagem', 'diagnostico diferencial'],
+    language: 'pt-BR',
+    refreshHours: 0,
+  },
+  {
+    id: 'who-emergency-care',
+    name: 'WHO Emergency and critical care',
+    url: 'https://www.who.int/health-topics/emergency-care',
+    kind: 'public-health',
+    topics: ['emergencias', 'triagem', 'seguranca'],
+    language: 'en',
+    refreshHours: 168,
+  },
+  {
+    id: 'cdc-pneumonia',
+    name: 'CDC Pneumonia',
+    url: 'https://www.cdc.gov/pneumonia/',
+    kind: 'public-health',
+    topics: ['respiratorio', 'infectologia', 'pneumonia'],
+    language: 'en',
+    refreshHours: 168,
+  },
+  {
+    id: 'nice-chest-pain',
+    name: 'NICE Chest pain guidance',
+    url: 'https://www.nice.org.uk/guidance/cg95',
+    kind: 'guideline',
+    topics: ['cardiologia', 'dor toracica', 'emergencias'],
+    language: 'en',
+    refreshHours: 720,
+  },
+  {
+    id: 'aha-cpr-ecc',
+    name: 'American Heart Association CPR & ECC',
+    url: 'https://cpr.heart.org/en/resuscitation-science/cpr-and-ecc-guidelines',
+    kind: 'guideline',
+    topics: ['cardiologia', 'emergencias', 'ressuscitacao'],
+    language: 'en',
+    refreshHours: 720,
+  },
+  {
+    id: 'msd-manual-professional',
+    name: 'MSD Manual Professional Edition',
+    url: 'https://www.msdmanuals.com/professional',
+    kind: 'reference',
+    topics: ['clinica geral', 'diagnostico diferencial', 'referencia'],
+    language: 'en',
+    refreshHours: 720,
+  },
+  {
+    id: 'open-guidelines-github',
+    name: 'Open guideline repositories on GitHub',
+    url: 'https://github.com/topics/clinical-guidelines',
+    kind: 'repository',
+    topics: ['github', 'guidelines', 'atualizacao'],
+    language: 'en',
+    refreshHours: 168,
+  },
+];
+
+const MASSIVE_SEED_DOMAINS = [
+  { id: 'cardiologia', label: 'Cardiologia', presentations: ['dor torácica', 'dispneia', 'síncope', 'palpitações', 'edema', 'choque', 'hipertensão', 'dor epigástrica', 'fadiga', 'sudorese'] },
+  { id: 'respiratorio', label: 'Respiratório', presentations: ['dispneia', 'tosse', 'hemoptise', 'dor pleurítica', 'sibilância', 'hipoxemia', 'febre', 'taquipneia', 'cianose', 'expectoração'] },
+  { id: 'neurologia', label: 'Neurologia', presentations: ['cefaleia', 'déficit focal', 'convulsão', 'confusão', 'síncope', 'vertigem', 'paresia', 'afasia', 'alteração visual', 'rigidez nucal'] },
+  { id: 'gastrointestinal', label: 'Gastrointestinal', presentations: ['dor abdominal', 'vômitos', 'diarreia', 'melena', 'hematoquezia', 'icterícia', 'anorexia', 'distensão', 'dor epigástrica', 'constipação'] },
+  { id: 'infectologia', label: 'Infectologia', presentations: ['febre', 'calafrios', 'sepse', 'rash', 'tosse febril', 'disúria febril', 'rigidez nucal', 'celulite', 'imunossupressão', 'prostração'] },
+  { id: 'nefro-uro', label: 'Nefro-urologia', presentations: ['disúria', 'hematúria', 'oligúria', 'anúria', 'dor lombar', 'edema', 'retenção urinária', 'polaciúria', 'cólica renal', 'febre urinária'] },
+  { id: 'endocrino', label: 'Endócrino-metabólico', presentations: ['hiperglicemia', 'hipoglicemia', 'perda de peso', 'poliúria', 'polidipsia', 'confusão', 'fraqueza', 'desidratação', 'cetoacidose', 'tremor'] },
+  { id: 'hematologia', label: 'Hematologia', presentations: ['anemia', 'sangramento', 'púrpura', 'trombose', 'fadiga', 'febre prolongada', 'linfonodos', 'palidez', 'equimoses', 'dor óssea'] },
+  { id: 'reumatologia', label: 'Reumatologia', presentations: ['artralgia', 'artrite', 'rash', 'febre', 'rigidez matinal', 'mialgia', 'úlcera oral', 'fenômeno de Raynaud', 'fadiga', 'edema articular'] },
+  { id: 'dermatologia', label: 'Dermatologia', presentations: ['rash', 'urticária', 'celulite', 'lesão bolhosa', 'prurido', 'petéquias', 'úlcera', 'eritema', 'necrose', 'descamação'] },
+  { id: 'gineco-obstetricia', label: 'Gineco-obstetrícia', presentations: ['dor pélvica', 'sangramento vaginal', 'atraso menstrual', 'corrimento', 'gestação', 'febre puerperal', 'hipertensão gestacional', 'vômitos', 'contrações', 'disúria'] },
+  { id: 'pediatria', label: 'Pediatria', presentations: ['febre infantil', 'tosse', 'desidratação', 'convulsão febril', 'vômitos', 'diarreia', 'rash', 'letargia', 'sibilância', 'dor abdominal'] },
+] as const;
+
+const INTERNAL_CONTEXT_LAYERS = [
+  { id: 'adulto', label: 'adulto', lens: 'contextualizar risco basal, comorbidades frequentes, medicações e sinais de deterioração' },
+  { id: 'idoso', label: 'idoso/frágil', lens: 'valorizar apresentações atípicas, quedas, delirium, polifarmácia, fragilidade e reserva fisiológica reduzida' },
+  { id: 'pediatrico', label: 'pediátrico', lens: 'adaptar linguagem, hidratação, comportamento, sinais de esforço e participação de responsáveis' },
+  { id: 'gestacao', label: 'gestação/puerpério', lens: 'considerar segurança materno-fetal, hipertensão, sangramento, trombose, infecção e avaliação obstétrica' },
+  { id: 'imunossupressao', label: 'imunossupressão', lens: 'baixar limiar para infecção grave, sintomas discretos, neutropenia, transplante e uso de imunobiológicos' },
+  { id: 'cardiometabolico', label: 'risco cardiometabólico', lens: 'integrar diabetes, hipertensão, doença renal, obesidade, dislipidemia e risco vascular' },
+  { id: 'emergencia', label: 'emergência', lens: 'priorizar ABCDE, sinais vitais, monitorização, reavaliação seriada e escalonamento presencial' },
+  { id: 'aps', label: 'atenção primária', lens: 'organizar longitudinalidade, prevenção, acompanhamento, educação e critérios de encaminhamento' },
+  { id: 'teletriagem', label: 'teletriagem', lens: 'explicitar limites remotos, perguntas de segurança, sinais de alarme e necessidade de avaliação presencial' },
+  { id: 'reavaliacao', label: 'reavaliação', lens: 'comparar evolução, resposta, surgimento de red flags e mudança de hipótese/prioridade' },
+  { id: 'recursos-limitados', label: 'recursos limitados', lens: 'focar exame clínico, estratificação de risco, segurança, transferência e exames essenciais' },
+  { id: 'medicamentos', label: 'risco medicamentoso', lens: 'investigar anticoagulantes, corticoides, imunossupressores, hipoglicemiantes, alergias e interações' },
+] as const;
+
+const MASSIVE_SEED_DIMENSIONS = [
+  { id: 'red-flags', title: 'red flags', focus: 'sinais de alarme, instabilidade, tempo de início e necessidade de avaliação presencial simulada' },
+  { id: 'history', title: 'anamnese dirigida', focus: 'cronologia, intensidade, fatores de melhora/piora, antecedentes e negativos pertinentes' },
+  { id: 'exam', title: 'exame físico orientado', focus: 'sinais vitais, estado geral, perfusão, oximetria e achados focais relevantes' },
+  { id: 'differential', title: 'diagnóstico diferencial', focus: 'hipóteses prováveis, hipóteses graves a excluir e mimetizadores comuns' },
+  { id: 'tests', title: 'exames iniciais', focus: 'exames de primeira linha, monitorização e interpretação contextual sem prescrição individual' },
+  { id: 'triage', title: 'triagem educacional', focus: 'priorização por risco, urgência, sinais de deterioração e reavaliação seriada' },
+  { id: 'safety', title: 'segurança e limites', focus: 'uso educacional, incerteza diagnóstica, validação profissional e diretrizes locais' },
+  { id: 'follow-up', title: 'reavaliação', focus: 'mudança de sintomas, resposta às medidas simuladas, retorno e escalonamento de cuidado' },
+] as const;
+
+function buildMassiveSeedRecords(): EvidenceRecord[] {
+  const records: EvidenceRecord[] = [];
+  const retrievedAt = new Date(0).toISOString();
+
+  for (const domain of MASSIVE_SEED_DOMAINS) {
+    for (const presentation of domain.presentations) {
+      for (const dimension of MASSIVE_SEED_DIMENSIONS) {
+        for (const context of INTERNAL_CONTEXT_LAYERS) {
+          const id = `internal-kb-${domain.id}-${normalizeText(presentation).replace(/\s+/g, '-')}-${dimension.id}-${context.id}`;
+          const title = `${domain.label}: ${presentation} — ${dimension.title} (${context.label})`;
+          const summary = `Base interna educacional para ${presentation} em ${domain.label}, com foco em ${dimension.focus}, aplicada ao contexto ${context.label}.`;
+
+          records.push({
+            id,
+            title,
+            sourceId: 'internal-massive-kb',
+            sourceName: 'Base interna massiva educacional',
+            sourceUrl: `internal://clinical-kb/${domain.id}/${dimension.id}/${context.id}`,
+            topics: [domain.id, domain.label.toLowerCase(), presentation, dimension.id, context.id, context.label, 'base interna', 'educacional'],
+            summary,
+            content: [
+              summary,
+              `Checklist sugerido: identificar início, evolução, intensidade, fatores associados e negativos relevantes para ${presentation}.`,
+              `Camada contextual: ${context.lens}.`,
+              `Prioridade: reconhecer instabilidade, sinais vitais alterados, red flags e necessidade de avaliação presencial quando aplicável.`,
+              `Diferenciais: organizar hipóteses prováveis e condições graves a excluir dentro de ${domain.label}, sem concluir diagnóstico definitivo.`,
+              `Exames: pensar em investigação inicial contextual e protocolos institucionais, sempre com supervisão profissional.`,
+              `Qualidade da anamnese: registrar impacto funcional, exposição, medicações, alergias, comorbidades, vulnerabilidades e dados negativos pertinentes.`,
+              'Aviso: conteúdo para estudo, simulação e apoio educacional; não substitui avaliação médica, diretriz local ou decisão clínica real.',
+            ].join(' '),
+            retrievedAt,
+            confidence: 'internal-generated',
+          });
+        }
+      }
+    }
+  }
+
+  return records;
+}
+
+const massiveSeedRecords = buildMassiveSeedRecords();
+
+const seedRecords: EvidenceRecord[] = [
+  {
+    id: 'seed-chest-pain-red-flags',
+    title: 'Dor torácica: prioridades educacionais',
+    sourceId: 'local-seed',
+    sourceName: 'Base educacional local',
+    sourceUrl: 'local://clinical-seed/chest-pain',
+    topics: ['cardiologia', 'dor toracica', 'emergencias'],
+    summary: 'Dor torácica com sudorese, dispneia, síncope, instabilidade ou fatores de risco exige priorização de ECG, sinais vitais e exclusão de causas graves.',
+    content:
+      'Em simulação educacional, dor torácica deve ser organizada por tempo de início, padrão da dor, irradiação, esforço/repouso, sintomas associados e red flags. ECG precoce, monitorização e troponina seriada são itens de investigação frequentemente discutidos em protocolos institucionais. Não é recomendação individual.',
+    retrievedAt: new Date(0).toISOString(),
+    confidence: 'seed',
+  },
+  {
+    id: 'seed-dyspnea-febrile',
+    title: 'Dispneia febril: pontos de gravidade',
+    sourceId: 'local-seed',
+    sourceName: 'Base educacional local',
+    sourceUrl: 'local://clinical-seed/dyspnea-fever',
+    topics: ['respiratorio', 'infectologia', 'pneumonia', 'emergencias'],
+    summary: 'Dispneia com febre deve destacar saturação, esforço respiratório, confusão, hipotensão, dor pleurítica e sinais de sepse.',
+    content:
+      'Para estudo, síndrome respiratória febril deve registrar início, tosse, expectoração, dor pleurítica, oximetria, comorbidades e critérios de gravidade. Hipoxemia, rebaixamento, instabilidade hemodinâmica e sepse simulada mudam prioridade de atendimento.',
+    retrievedAt: new Date(0).toISOString(),
+    confidence: 'seed',
+  },
+  {
+    id: 'seed-abdominal-pain',
+    title: 'Dor abdominal: cronologia e sinais cirúrgicos',
+    sourceId: 'local-seed',
+    sourceName: 'Base educacional local',
+    sourceUrl: 'local://clinical-seed/abdominal-pain',
+    topics: ['gastrointestinal', 'dor abdominal', 'cirurgia', 'emergencias'],
+    summary: 'Dor migratória, sinais peritoneais, vômitos persistentes, febre, sangramento, gravidez e instabilidade são pistas de maior risco.',
+    content:
+      'Casos educacionais de dor abdominal se beneficiam de localização, migração, intensidade, fatores de piora, náuseas/vômitos, hábito intestinal, sintomas urinários/ginecológicos e red flags. A avaliação é sempre contextual e simulada.',
+    retrievedAt: new Date(0).toISOString(),
+    confidence: 'seed',
+  },
+];
+
+const internalSeedRecords = [...seedRecords, ...massiveSeedRecords];
+let evidenceRecords = [...internalSeedRecords];
+let evidenceSearchIndex: EvidenceSearchDocument[] = [];
+let loadedFromDisk = false;
+let lastRefreshAt: string | null = null;
+
+function normalizeText(value: string) {
+  return value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokenize(value: string) {
+  return normalizeText(value)
+    .split(' ')
+    .filter((term) => term.length >= 3);
+}
+
+function buildEvidenceSearchIndex(records: EvidenceRecord[]): EvidenceSearchDocument[] {
+  return records.map((record) => ({
+    record,
+    haystack: normalizeText([record.title, record.summary, record.content, record.topics.join(' ')].join(' ')),
+    titleText: normalizeText(record.title),
+  }));
+}
+
+function setEvidenceRecords(records: EvidenceRecord[]) {
+  evidenceRecords = records;
+  evidenceSearchIndex = buildEvidenceSearchIndex(records);
+}
+
+function recordHash(input: string) {
+  return crypto.createHash('sha256').update(input).digest('hex').slice(0, 16);
+}
+
+function stripHtml(html: string) {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function extractTitle(html: string, fallback: string) {
+  const title = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1];
+  return stripHtml(title || fallback).slice(0, 140) || fallback;
+}
+
+function summarize(text: string) {
+  const sentences = text.match(/[^.!?]+[.!?]+/g) || [text];
+  return sentences.slice(0, 3).join(' ').slice(0, 700).trim();
+}
+
+setEvidenceRecords(evidenceRecords);
+
+function mergeEvidenceRecords(primary: EvidenceRecord[], secondary: EvidenceRecord[]) {
+  const byId = new Map<string, EvidenceRecord>();
+  for (const record of [...primary, ...secondary]) byId.set(record.id, record);
+  return [...byId.values()];
+}
+
+function sourceToRecord(source: EvidenceSource, rawHtml: string): EvidenceRecord {
+  const title = extractTitle(rawHtml, source.name);
+  const text = stripHtml(rawHtml).slice(0, MAX_REMOTE_TEXT_CHARS);
+  const now = new Date().toISOString();
+
+  return {
+    id: `remote-${source.id}-${recordHash(`${source.url}:${title}:${text.slice(0, 500)}`)}`,
+    title,
+    sourceId: source.id,
+    sourceName: source.name,
+    sourceUrl: source.url,
+    topics: source.topics,
+    summary: summarize(text) || `Fonte monitorada: ${source.name}`,
+    content: text,
+    retrievedAt: now,
+    updatedAt: now,
+    confidence: 'remote-refreshed',
+  };
+}
+
+async function persistEvidenceStore() {
+  const payload = { savedAt: new Date().toISOString(), records: evidenceRecords, lastRefreshAt };
+  await fs.writeFile(EVIDENCE_STORE_FILE, JSON.stringify(payload), 'utf-8');
+}
+
+export async function loadEvidenceStore() {
+  if (loadedFromDisk) return evidenceRecords;
+  loadedFromDisk = true;
+
+  try {
+    const raw = await fs.readFile(EVIDENCE_STORE_FILE, 'utf-8');
+    const parsed = JSON.parse(raw) as { records?: EvidenceRecord[]; lastRefreshAt?: string | null };
+    if (Array.isArray(parsed.records) && parsed.records.length > 0) {
+      setEvidenceRecords(mergeEvidenceRecords(internalSeedRecords, parsed.records));
+      lastRefreshAt = parsed.lastRefreshAt || null;
+    }
+  } catch {
+    // Keep seed records when the optional disk cache does not exist or is invalid.
+  }
+
+  return evidenceRecords;
+}
+
+export async function getEvidenceStatus() {
+  await loadEvidenceStore();
+  const remoteRecords = evidenceRecords.filter((record) => record.confidence === 'remote-refreshed').length;
+
+  return {
+    records: evidenceRecords.length,
+    seedRecords: evidenceRecords.length - remoteRecords,
+    curatedSeedRecords: seedRecords.length,
+    massiveSeedRecords: massiveSeedRecords.length,
+    internalContexts: INTERNAL_CONTEXT_LAYERS.length,
+    internalDomains: MASSIVE_SEED_DOMAINS.length,
+    internalDimensions: MASSIVE_SEED_DIMENSIONS.length,
+    internalMode: true,
+    remoteRecords,
+    sources: evidenceSources.length,
+    sourceRegistry: evidenceSources,
+    lastRefreshAt,
+    remoteRefreshEnabled: process.env.EVIDENCE_AGENT_ALLOW_REMOTE === 'true',
+    storeFile: EVIDENCE_STORE_FILE,
+    safety: 'Base para estudo e contexto educacional; não substitui diretrizes locais, revisão médica ou decisão clínica real.',
+  };
+}
+
+export async function searchEvidence(params: { query?: string; topic?: string; limit?: number }) {
+  await loadEvidenceStore();
+  const limit = Math.min(Math.max(params.limit || 8, 1), 20);
+  const terms = tokenize([params.query || '', params.topic || ''].join(' '));
+  const topic = normalizeText(params.topic || '');
+
+  const scored = evidenceSearchIndex
+    .map(({ record, haystack, titleText }): EvidenceSearchResult => {
+      const matchedTerms = terms.filter((term) => haystack.includes(term));
+      const topicBoost = topic && record.topics.some((item) => normalizeText(item).includes(topic)) ? 3 : 0;
+      const titleBoost = matchedTerms.filter((term) => titleText.includes(term)).length * 2;
+      return {
+        ...record,
+        score: matchedTerms.length + topicBoost + titleBoost,
+        matchedTerms,
+      };
+    })
+    .filter((record) => (terms.length > 0 || topic ? record.score > 0 : true))
+    .sort((a, b) => b.score - a.score || b.retrievedAt.localeCompare(a.retrievedAt));
+
+  return scored.slice(0, limit);
+}
+
+export async function refreshEvidenceFromSources() {
+  await loadEvidenceStore();
+  if (process.env.EVIDENCE_AGENT_ALLOW_REMOTE !== 'true') {
+    return {
+      refreshed: false,
+      reason: 'Remote refresh disabled. Set EVIDENCE_AGENT_ALLOW_REMOTE=true to enable curated source fetching.',
+      records: evidenceRecords.length,
+    };
+  }
+
+  const refreshed: EvidenceRecord[] = [];
+  const refreshableSources = evidenceSources.filter((source) => source.kind !== 'internal-kb');
+
+  for (const source of refreshableSources.slice(0, MAX_RECORDS_PER_REFRESH)) {
+    try {
+      const response = await fetch(source.url, {
+        headers: {
+          'User-Agent': 'ClinicIntuitionEvidenceAgent/1.0 educational updater',
+        },
+      });
+      if (!response.ok) continue;
+      const html = await response.text();
+      refreshed.push(sourceToRecord(source, html));
+    } catch {
+      // Source refresh is opportunistic; failed sources remain covered by seed/cache records.
+    }
+  }
+
+  if (refreshed.length > 0) {
+    const byId = new Map(evidenceRecords.map((record) => [record.id, record]));
+    for (const record of refreshed) byId.set(record.id, record);
+    setEvidenceRecords([...byId.values()]);
+    lastRefreshAt = new Date().toISOString();
+    await persistEvidenceStore();
+  }
+
+  return {
+    refreshed: refreshed.length > 0,
+    added: refreshed.length,
+    records: evidenceRecords.length,
+    lastRefreshAt,
+  };
+}

--- a/backend/server.test.ts
+++ b/backend/server.test.ts
@@ -26,6 +26,39 @@ describe('backend server routes', () => {
     expect(typeof response.body.sessionCacheSize).toBe('number');
   });
 
+
+  it('GET /api/evidence/status expõe agente de evidências educacional', async () => {
+    const app = createApp();
+    const response = await request(app).get('/api/evidence/status');
+
+    expect(response.status).toBe(200);
+    expect(response.body.records).toBeGreaterThan(10_000);
+    expect(response.body.sources).toBeGreaterThan(0);
+    expect(response.body.massiveSeedRecords).toBeGreaterThan(10_000);
+    expect(response.body.internalMode).toBe(true);
+    expect(response.body.internalContexts).toBeGreaterThan(10);
+    expect(response.body.safety).toContain('educacional');
+  });
+
+  it('GET /api/evidence/search retorna resultados por tema', async () => {
+    const app = createApp();
+    const response = await request(app).get('/api/evidence/search').query({ q: 'dor torácica ECG', topic: 'cardiologia' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.count).toBeGreaterThan(0);
+    expect(response.body.results[0].title).toBeTruthy();
+    expect(response.body.educationalWarning).toContain('educacional');
+  });
+
+  it('POST /api/evidence/refresh respeita flag de atualização remota', async () => {
+    const app = createApp();
+    const response = await request(app).post('/api/evidence/refresh').send({});
+
+    expect(response.status).toBe(200);
+    expect(response.body.refreshed).toBe(false);
+    expect(response.body.reason).toContain('EVIDENCE_AGENT_ALLOW_REMOTE');
+  });
+
   it('POST /api/clinical-analysis retorna 400 para payload inválido', async () => {
     const app = createApp();
     const response = await request(app).post('/api/clinical-analysis').send({});

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -11,6 +11,7 @@ import { mergeClinicalWithFallback } from '../shared/clinicalResponse.js';
 import { buildMedbotLocalContent } from '../shared/medbotLocal.js';
 import { getTopicReferences } from '../shared/clinicalReferences.js';
 import { isMedbotAnswerSafe } from '../shared/medbotSafety.js';
+import { getEvidenceStatus, refreshEvidenceFromSources, searchEvidence } from './evidenceAgent';
 
 dotenv.config();
 
@@ -765,6 +766,30 @@ export function createApp() {
       sessionCacheSize: sessionCache.size,
       timestamp: new Date().toISOString(),
     });
+  });
+
+
+  app.get('/api/evidence/status', async (_req, res) => {
+    res.json(await getEvidenceStatus());
+  });
+
+  app.get('/api/evidence/search', async (req, res) => {
+    const query = typeof req.query.q === 'string' ? req.query.q : '';
+    const topic = typeof req.query.topic === 'string' ? req.query.topic : '';
+    const limit = typeof req.query.limit === 'string' ? Number(req.query.limit) : undefined;
+    const results = await searchEvidence({ query, topic, limit });
+
+    res.json({
+      query,
+      topic,
+      count: results.length,
+      results,
+      educationalWarning: 'Resultados para estudo e contexto educacional; valide em diretrizes locais e fontes oficiais antes de qualquer decisão clínica real.',
+    });
+  });
+
+  app.post('/api/evidence/refresh', async (_req, res) => {
+    res.json(await refreshEvidenceFromSources());
   });
 
   app.post('/api/clinical-analysis', async (req, res) => {

--- a/src/components/DiagnosisResult.tsx
+++ b/src/components/DiagnosisResult.tsx
@@ -1,24 +1,34 @@
+import { lazy, Suspense, useMemo, useState, type ReactNode } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Separator } from '@/components/ui/separator';
-import { VoiceAssistant } from '@/components/voice/VoiceAssistant';
+import { Progress } from '@/components/ui/progress';
 import { formatAssessmentForSpeech } from '@/lib/spokenClinicalFormatter';
-import { ClinicalAssessment, PatientData } from '@/lib/medicalKnowledge';
+import type { ClinicalAssessment, PatientData } from '@/lib/medicalKnowledge';
 import {
-  Stethoscope,
-  Pill,
-  BookOpen,
-  Search,
-  AlertTriangle,
-  RotateCcw,
-  User,
-  Calendar,
-  Users,
-  FlaskConical,
-  ClipboardCheck,
   Activity,
+  AlertTriangle,
+  BookOpen,
+  Calendar,
+  CheckCircle2,
+  ClipboardCheck,
+  Copy,
+  FlaskConical,
+  Gauge,
+  Pill,
+  RotateCcw,
+  Search,
+  ShieldAlert,
+  Sparkles,
+  Stethoscope,
+  User,
+  Users,
+  type LucideIcon,
 } from 'lucide-react';
+
+const VoiceAssistant = lazy(() =>
+  import('@/components/voice/VoiceAssistant').then((module) => ({ default: module.VoiceAssistant })),
+);
 
 const REGULATORY_REFERENCES = [
   'Lei Geral de Proteção de Dados (Lei nº 13.709/2018 - LGPD)',
@@ -32,253 +42,306 @@ interface DiagnosisResultProps {
   onReset: () => void;
 }
 
+const voiceFallback = (
+  <div className="rounded-2xl border border-primary/10 bg-primary-soft/20 p-4 text-sm font-medium text-muted-foreground">
+    Preparando leitura em voz alta...
+  </div>
+);
+
+const getProbabilityColor = (probability: string) => {
+  switch (probability.toLowerCase()) {
+    case 'alta':
+      return 'bg-destructive text-destructive-foreground';
+    case 'moderada':
+      return 'bg-warning text-warning-foreground';
+    case 'baixa':
+      return 'bg-success text-success-foreground';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+};
+
+const getTriageColor = (triageLevel: ClinicalAssessment['triageLevel']) => {
+  switch (triageLevel) {
+    case 'Emergência':
+      return 'bg-destructive text-destructive-foreground';
+    case 'Urgente':
+      return 'bg-orange-500 text-white';
+    case 'Prioritário':
+      return 'bg-warning text-warning-foreground';
+    default:
+      return 'bg-success text-success-foreground';
+  }
+};
+
+const getTriageProgress = (triageLevel: ClinicalAssessment['triageLevel']) => {
+  switch (triageLevel) {
+    case 'Emergência':
+      return 100;
+    case 'Urgente':
+      return 78;
+    case 'Prioritário':
+      return 55;
+    default:
+      return 28;
+  }
+};
+
+const formatClinicalReport = (diagnosis: ClinicalAssessment, patientData: PatientData) => {
+  const hypotheses = diagnosis.hypotheses
+    .map((hypothesis, index) => {
+      const probability = typeof hypothesis.probabilityPercent === 'number'
+        ? `${hypothesis.probability} (${hypothesis.probabilityPercent}%)`
+        : hypothesis.probability;
+
+      return [
+        `${index + 1}. ${hypothesis.name} — ${probability} | score ${hypothesis.score}`,
+        `   Conduta educacional: ${hypothesis.treatment}`,
+        `   Exames: ${hypothesis.recommendedExams.join(', ') || 'não informado'}`,
+        `   Red flags: ${hypothesis.redFlags.join(', ') || 'não informado'}`,
+      ].join('\n');
+    })
+    .join('\n\n');
+
+  return [
+    'Dr. IA — Resumo educacional do caso',
+    `Paciente: ${patientData.name || 'Não informado'} | ${patientData.age} anos | ${patientData.gender || 'gênero não informado'} | duração: ${patientData.duration}`,
+    `Sintomas: ${patientData.symptoms}`,
+    '',
+    `Triagem: ${diagnosis.triageLevel}`,
+    `Motivo: ${diagnosis.triageReason}`,
+    '',
+    `Resumo clínico: ${diagnosis.clinicalSummary}`,
+    '',
+    `Ações imediatas simuladas: ${diagnosis.immediateActions.join('; ') || 'não informado'}`,
+    `Exames sugeridos: ${diagnosis.suggestedExams.join('; ') || 'não informado'}`,
+    '',
+    'Hipóteses:',
+    hypotheses || 'Sem hipóteses listadas.',
+    '',
+    'Aviso: conteúdo exclusivamente educacional; não constitui diagnóstico, prescrição ou conduta médica real.',
+  ].join('\n');
+};
+
 export const DiagnosisResult = ({ diagnosis, patientData, onReset }: DiagnosisResultProps) => {
+  const [copyStatus, setCopyStatus] = useState('');
   const spokenAssessment = formatAssessmentForSpeech(diagnosis, patientData);
+  const primaryHypothesis = diagnosis.hypotheses[0];
+  const triageProgress = getTriageProgress(diagnosis.triageLevel);
+  const clinicalReport = useMemo(() => formatClinicalReport(diagnosis, patientData), [diagnosis, patientData]);
 
-  const getProbabilityColor = (probability: string) => {
-    switch (probability.toLowerCase()) {
-      case 'alta':
-        return 'bg-destructive text-destructive-foreground';
-      case 'moderada':
-        return 'bg-warning text-warning-foreground';
-      case 'baixa':
-        return 'bg-success text-success-foreground';
-      default:
-        return 'bg-muted text-muted-foreground';
-    }
-  };
+  const summaryStats = [
+    { label: 'Hipóteses', value: diagnosis.hypotheses.length, icon: Stethoscope },
+    { label: 'Exames', value: diagnosis.suggestedExams.length, icon: FlaskConical },
+    { label: 'Ações', value: diagnosis.immediateActions.length, icon: ClipboardCheck },
+    { label: 'Alertas', value: diagnosis.validationWarnings?.length || 0, icon: ShieldAlert },
+  ];
 
-  const getTriageColor = (triageLevel: ClinicalAssessment['triageLevel']) => {
-    switch (triageLevel) {
-      case 'Emergência':
-        return 'bg-destructive text-destructive-foreground';
-      case 'Urgente':
-        return 'bg-orange-500 text-white';
-      case 'Prioritário':
-        return 'bg-warning text-warning-foreground';
-      default:
-        return 'bg-success text-success-foreground';
+  const handleCopyReport = async () => {
+    if (!navigator.clipboard) {
+      setCopyStatus('Cópia indisponível neste navegador.');
+      return;
     }
+
+    await navigator.clipboard.writeText(clinicalReport);
+    setCopyStatus('Resumo copiado.');
+    window.setTimeout(() => setCopyStatus(''), 2200);
   };
 
   return (
-    <div className="space-y-4 sm:space-y-6 animate-fade-in">
-      <Card className="border-primary/20 shadow-lg">
-        <CardHeader className="bg-gradient-to-r from-primary-soft via-primary-soft/80 to-accent border-b">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-primary/20 rounded-lg">
-                <User className="h-5 w-5 sm:h-6 sm:w-6 text-primary" />
+    <div className="animate-fade-in space-y-5 sm:space-y-6">
+      <Card className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <CardHeader className="border-b border-slate-200 bg-white p-5 sm:p-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="flex items-start gap-3">
+              <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-primary-soft text-primary">
+                <User className="h-6 w-6" />
               </div>
               <div>
-                <CardTitle className="text-lg sm:text-xl">Resumo do Paciente</CardTitle>
-                <CardDescription className="text-sm sm:text-base">Caso analisado pelo sistema Dr. IA</CardDescription>
+                <Badge variant="outline" className="mb-2 border-slate-200 bg-slate-50 text-slate-600">
+                  <Sparkles className="mr-1 h-3 w-3" />
+                  Resultado educacional
+                </Badge>
+                <CardTitle className="text-xl font-semibold text-slate-950 sm:text-2xl">Resumo do Paciente</CardTitle>
+                <CardDescription className="mt-1 text-sm sm:text-base">
+                  Caso analisado pelo Dr. IA com triagem, hipóteses e próximos passos simulados.
+                </CardDescription>
               </div>
             </div>
-            <Button
-              onClick={onReset}
-              variant="outline"
-              size="sm"
-              className="gap-2 hover:bg-primary/10 hover:text-primary transition-colors shrink-0"
-            >
-              <RotateCcw className="h-4 w-4" />
-              <span className="hidden sm:inline">Novo Caso</span>
-              <span className="sm:hidden">Novo</span>
-            </Button>
+            <div className="flex flex-col gap-2 sm:flex-row lg:self-center">
+              <Button
+                onClick={handleCopyReport}
+                variant="outline"
+                size="sm"
+                className="h-10 rounded-xl border-slate-200 bg-white px-4 font-medium transition-colors hover:bg-primary/10 hover:text-primary"
+              >
+                {copyStatus ? <CheckCircle2 className="h-4 w-4 text-emerald-600" /> : <Copy className="h-4 w-4" />}
+                {copyStatus ? 'Copiado' : 'Copiar resumo'}
+              </Button>
+              <Button
+                onClick={onReset}
+                variant="outline"
+                size="sm"
+                className="h-10 rounded-xl border-slate-200 bg-white px-4 font-medium transition-colors hover:bg-primary/10 hover:text-primary"
+              >
+                <RotateCcw className="h-4 w-4" />
+                Novo Caso
+              </Button>
+            </div>
           </div>
+          {copyStatus && <p className="mt-3 text-sm font-medium text-emerald-600">{copyStatus}</p>}
         </CardHeader>
-        <CardContent className="p-4 sm:p-6 space-y-4">
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            <div className="flex items-center gap-2">
-              <User className="h-4 w-4 text-muted-foreground" />
-              <div>
-                <p className="text-sm text-muted-foreground">Nome</p>
-                <p className="font-medium">{patientData.name || 'Não informado'}</p>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <Calendar className="h-4 w-4 text-muted-foreground" />
-              <div>
-                <p className="text-sm text-muted-foreground">Idade</p>
-                <p className="font-medium">{patientData.age} anos</p>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <Users className="h-4 w-4 text-muted-foreground" />
-              <div>
-                <p className="text-sm text-muted-foreground">Gênero</p>
-                <p className="font-medium capitalize">{patientData.gender}</p>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <AlertTriangle className="h-4 w-4 text-muted-foreground" />
-              <div>
-                <p className="text-sm text-muted-foreground">Duração</p>
-                <p className="font-medium">{patientData.duration}</p>
-              </div>
-            </div>
+
+        <CardContent className="space-y-5 p-4 sm:p-6 lg:p-8">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <InfoTile icon={User} label="Nome" value={patientData.name || 'Não informado'} />
+            <InfoTile icon={Calendar} label="Idade" value={`${patientData.age} anos`} />
+            <InfoTile icon={Users} label="Gênero" value={patientData.gender} capitalize />
+            <InfoTile icon={AlertTriangle} label="Duração" value={patientData.duration} />
           </div>
 
-          <Separator />
-
-          <div className="grid gap-4 lg:grid-cols-[1.3fr_0.7fr]">
-            <div className="space-y-3">
-              <p className="text-sm text-muted-foreground">Sintomas relatados</p>
-              <div className="bg-gradient-to-r from-muted/50 to-muted p-3 sm:p-4 rounded-lg border border-border/50">
-                <p className="text-sm sm:text-base leading-relaxed">{patientData.symptoms}</p>
-              </div>
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1.25fr)_minmax(18rem,0.75fr)]">
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Sintomas relatados</p>
+              <p className="text-sm leading-7 text-slate-700 sm:text-base">{patientData.symptoms}</p>
             </div>
 
-            <div className="grid grid-cols-1 gap-3">
-              <div className="rounded-lg border p-4 bg-background/70">
-                <div className="flex items-center gap-2 mb-2">
-                  <Activity className="h-4 w-4 text-primary" />
-                  <p className="text-sm font-semibold">Triagem</p>
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <Activity className="h-5 w-5 text-primary" />
+                  <p className="font-semibold text-slate-900">Triagem</p>
                 </div>
                 <Badge className={getTriageColor(diagnosis.triageLevel)}>{diagnosis.triageLevel}</Badge>
-                <p className="text-sm text-muted-foreground mt-2">{diagnosis.triageReason}</p>
               </div>
+              <Progress value={triageProgress} className="h-2.5" />
+              <p className="mt-3 text-sm leading-6 text-muted-foreground">{diagnosis.triageReason}</p>
             </div>
           </div>
+
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {summaryStats.map(({ label, value, icon: Icon }) => (
+              <div key={label} className="rounded-xl border border-slate-200 bg-white p-4">
+                <Icon className="mb-3 h-5 w-5 text-primary" />
+                <p className="text-2xl font-semibold text-slate-950">{value}</p>
+                <p className="text-xs font-bold uppercase tracking-wide text-muted-foreground">{label}</p>
+              </div>
+            ))}
+          </div>
+
+          {primaryHypothesis && (
+            <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 sm:p-5">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-700">Hipótese líder</p>
+                  <p className="mt-1 text-lg font-semibold text-slate-950">{primaryHypothesis.name}</p>
+                </div>
+                <Badge className={getProbabilityColor(primaryHypothesis.probability)}>
+                  {primaryHypothesis.probability}
+                  {typeof primaryHypothesis.probabilityPercent === 'number' ? ` ${primaryHypothesis.probabilityPercent}%` : ''}
+                </Badge>
+              </div>
+            </div>
+          )}
         </CardContent>
       </Card>
 
       {diagnosis.emergencyWarning && (
-        <Card className="border-destructive bg-gradient-to-r from-destructive/5 to-red-50/50 shadow-lg animate-pulse">
+        <Card className="overflow-hidden rounded-2xl border-destructive/30 bg-rose-50 shadow-sm">
           <CardContent className="p-4 sm:p-6">
             <div className="flex items-start gap-3">
-              <div className="p-2 bg-destructive/20 rounded-full">
-                <AlertTriangle className="h-6 w-6 text-destructive flex-shrink-0" />
+              <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-destructive/10 text-destructive">
+                <AlertTriangle className="h-6 w-6" />
               </div>
-              <div className="flex-1">
-                <h3 className="font-bold text-destructive text-lg sm:text-xl mb-3 flex items-center gap-2">🚨 ALERTA DE EMERGÊNCIA</h3>
-                <p className="text-destructive/90 text-sm sm:text-base leading-relaxed">{diagnosis.emergencyWarning}</p>
-                <div className="mt-4 p-3 bg-destructive/10 rounded-lg border border-destructive/20">
-                  <p className="text-xs sm:text-sm font-medium text-destructive">📞 Em caso de emergência real: SAMU 192 | Bombeiros 193</p>
-                </div>
+              <div>
+                <h3 className="text-lg font-semibold text-destructive sm:text-xl">Alerta de emergência</h3>
+                <p className="mt-2 text-sm leading-7 text-destructive/90 sm:text-base">{diagnosis.emergencyWarning}</p>
               </div>
             </div>
           </CardContent>
         </Card>
       )}
 
-      <Card className="shadow-sm border-primary/15">
-        <CardHeader>
-          <CardTitle className="text-lg sm:text-xl">Resumo clínico</CardTitle>
-          <CardDescription>{diagnosis.clinicalSummary}</CardDescription>
+      <Card className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <CardHeader className="border-b border-slate-200 bg-white p-5 sm:p-6">
+          <CardTitle className="flex items-center gap-2 text-xl font-semibold text-slate-950 sm:text-2xl">
+            <Gauge className="h-6 w-6 text-primary" />
+            Síntese clínica e plano de estudo
+          </CardTitle>
+          <CardDescription>Resumo narrativo, ações imediatas simuladas, exames sugeridos e conformidade educacional.</CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <VoiceAssistant
-            title="Leitura segura do resultado"
-            description="Ouça uma versão curta da triagem, hipóteses, exames e ações, mantendo o aviso educacional."
-            speechText={spokenAssessment}
-            speakLabel="Ler resultado"
-          />
+        <CardContent className="grid gap-4 p-4 sm:p-6 lg:grid-cols-2 lg:p-8">
+          <InsightCard title="Resumo clínico" icon={BookOpen} tone="primary">
+            <p>{diagnosis.clinicalSummary}</p>
+          </InsightCard>
 
-          <div className="grid gap-4 lg:grid-cols-2">
-            <div className="rounded-lg border bg-primary-soft/30 p-4">
-              <div className="flex items-center gap-2 mb-3">
-                <FlaskConical className="h-4 w-4 text-primary" />
-                <h3 className="font-semibold">Exames sugeridos</h3>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {diagnosis.suggestedExams.map((exam) => (
-                  <Badge key={exam} variant="secondary" className="text-xs">{exam}</Badge>
-                ))}
-              </div>
-            </div>
+          <InsightCard title="Ações imediatas simuladas" icon={ClipboardCheck} tone="success">
+            <ListItems items={diagnosis.immediateActions} emptyText="Sem ações imediatas adicionais." />
+          </InsightCard>
 
-            <div className="rounded-lg border bg-success-soft/40 p-4">
-              <div className="flex items-center gap-2 mb-3">
-                <ClipboardCheck className="h-4 w-4 text-success" />
-                <h3 className="font-semibold">Ações imediatas</h3>
-              </div>
-              <ul className="space-y-2 text-sm text-muted-foreground list-disc pl-5">
-                {diagnosis.immediateActions.map((action) => (
-                  <li key={action}>{action}</li>
-                ))}
-              </ul>
+          <InsightCard title="Exames sugeridos" icon={FlaskConical} tone="neutral">
+            <ListItems items={diagnosis.suggestedExams} emptyText="Sem exames adicionais sugeridos." badge />
+          </InsightCard>
+
+          <InsightCard title="Referências regulatórias" icon={ShieldAlert} tone="warning">
+            <ListItems items={REGULATORY_REFERENCES} emptyText="Sem referências regulatórias." />
+          </InsightCard>
+
+          {diagnosis.validationWarnings && diagnosis.validationWarnings.length > 0 && (
+            <div className="lg:col-span-2">
+              <InsightCard title="Validações de segurança" icon={AlertTriangle} tone="danger">
+                <ListItems items={diagnosis.validationWarnings} emptyText="Sem avisos de validação." />
+              </InsightCard>
             </div>
+          )}
+
+          <div className="lg:col-span-2">
+            <Suspense fallback={voiceFallback}>
+              <VoiceAssistant
+                title="Resumo por voz"
+                description="Ouça a síntese clínica simulada em português para revisar o raciocínio sem sair da tela."
+                speechText={spokenAssessment}
+                speakLabel="Ouvir resumo"
+              />
+            </Suspense>
           </div>
         </CardContent>
       </Card>
 
-      {diagnosis.validationWarnings && diagnosis.validationWarnings.length > 0 && (
-        <Card className="border-warning/50 bg-warning-soft/30">
-          <CardHeader>
-            <CardTitle className="text-base sm:text-lg">Validações de segurança aplicadas</CardTitle>
-            <CardDescription>
-              A resposta externa foi filtrada e o sistema priorizou dados locais seguros para evitar inconsistências.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <ul className="list-disc pl-5 text-sm text-muted-foreground space-y-1">
-              {diagnosis.validationWarnings.map((warning) => (
-                <li key={warning}>{warning}</li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
-      )}
+      <div className="space-y-4">
+        {diagnosis.hypotheses.map((hypothesis, index) => {
+          const probabilityValue = typeof hypothesis.probabilityPercent === 'number' ? hypothesis.probabilityPercent : hypothesis.score;
 
-      <Card className="border-border/60">
-        <CardHeader>
-          <CardTitle className="text-base sm:text-lg">Referências regulatórias (Brasil)</CardTitle>
-          <CardDescription>
-            Base legal e ética para uso educacional seguro do simulador com dados de saúde no contexto brasileiro.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <ul className="space-y-2 text-sm">
-            {REGULATORY_REFERENCES.map((ref) => (
-              <li key={ref} className="text-muted-foreground">
-                {ref}
-              </li>
-            ))}
-          </ul>
-        </CardContent>
-      </Card>
-
-      <div className="space-y-4 sm:space-y-6">
-        <h2 className="text-xl sm:text-2xl font-bold text-foreground flex items-center gap-2">
-          <div className="p-2 bg-primary/20 rounded-lg">
-            <Stethoscope className="h-5 w-5 sm:h-6 sm:w-6 text-primary" />
-          </div>
-          Análise diagnóstica
-        </h2>
-
-        {diagnosis.hypotheses.map((hypothesis, index) => (
-          <Card key={`${hypothesis.name}-${index}`} className="border-l-4 border-l-primary shadow-sm">
-            <CardHeader className="pb-3">
-              <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-                <div className="flex-1">
-                  <CardTitle className="text-lg sm:text-xl flex items-start gap-2 leading-tight">
-                    <span className="text-2xl">🩺</span>
-                    <div>
-                      <div className="font-bold">Hipótese {index + 1}</div>
-                      <div className="text-base sm:text-lg font-semibold text-primary">{hypothesis.name}</div>
+          return (
+            <Card key={`${hypothesis.name}-${index}`} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+              <CardHeader className="border-b border-slate-200 bg-white p-5 sm:p-6">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="flex items-start gap-3">
+                    <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                      <Stethoscope className="h-5 w-5" />
                     </div>
-                  </CardTitle>
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">Hipótese {index + 1}</p>
+                      <CardTitle className="mt-1 text-lg font-semibold text-primary sm:text-xl">{hypothesis.name}</CardTitle>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge className={getProbabilityColor(hypothesis.probability)}>
+                      {hypothesis.probability}
+                      {typeof hypothesis.probabilityPercent === 'number' ? ` ${hypothesis.probabilityPercent}%` : ''}
+                    </Badge>
+                    <Badge variant="outline" className="bg-white">Score {hypothesis.score}</Badge>
+                  </div>
                 </div>
-                <div className="flex items-center gap-2 shrink-0">
-                  <Badge className={`${getProbabilityColor(hypothesis.probability)} text-xs sm:text-sm`}>
-                    {hypothesis.probability}
-                    {typeof hypothesis.probabilityPercent === 'number' ? ` ${hypothesis.probabilityPercent}%` : ''}
-                  </Badge>
-                  <Badge variant="outline" className="text-xs">Score {hypothesis.score}</Badge>
-                </div>
-              </div>
-            </CardHeader>
+                <Progress value={Math.min(Math.max(probabilityValue, 0), 100)} className="mt-4 h-2" />
+              </CardHeader>
 
-            <CardContent className="space-y-4 pt-0">
-              <div className="bg-success-soft p-3 sm:p-4 rounded-lg border border-success/20">
-                <div className="flex items-start gap-3">
-                  <Pill className="h-5 w-5 text-success mt-0.5 flex-shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <h4 className="font-semibold text-success mb-2 text-sm sm:text-base">💊 Possível conduta terapêutica</h4>
-                    <p className="text-success/90 text-sm leading-relaxed">{hypothesis.treatment}</p>
+              <CardContent className="space-y-4 p-4 sm:p-6">
+                <div className="grid gap-4 lg:grid-cols-2">
+                  <InsightCard title="Possível conduta terapêutica" icon={Pill} tone="success">
+                    <p>{hypothesis.treatment}</p>
                     {hypothesis.medicationOptions && hypothesis.medicationOptions.length > 0 && (
-                      <ul className="mt-3 space-y-1 text-xs sm:text-sm text-success/90 list-disc pl-5">
+                      <ul className="mt-3 list-disc space-y-1 pl-5">
                         {hypothesis.medicationOptions.slice(0, 3).map((option) => (
                           <li key={`${option.name}-${option.why}`}>
                             <strong>{option.name}:</strong> {option.why}
@@ -286,71 +349,52 @@ export const DiagnosisResult = ({ diagnosis, patientData, onReset }: DiagnosisRe
                         ))}
                       </ul>
                     )}
-                  </div>
-                </div>
-              </div>
+                  </InsightCard>
 
-              <div className="bg-primary-soft p-3 sm:p-4 rounded-lg border border-primary/20">
-                <div className="flex items-start gap-3">
-                  <BookOpen className="h-5 w-5 text-primary mt-0.5 flex-shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <h4 className="font-semibold text-primary mb-2 text-sm sm:text-base">📌 Explicação clínica</h4>
-                    <p className="text-primary/90 text-sm leading-relaxed">{hypothesis.explanation}</p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="grid gap-4 lg:grid-cols-2">
-                <div className="bg-accent p-3 sm:p-4 rounded-lg border border-accent/20">
-                  <div className="flex items-start gap-3">
-                    <Search className="h-5 w-5 text-accent-foreground mt-0.5 flex-shrink-0" />
-                    <div className="flex-1 min-w-0">
-                      <h4 className="font-semibold text-accent-foreground mb-3 text-sm sm:text-base">🔍 Diagnósticos diferenciais</h4>
-                      <div className="flex flex-wrap gap-2">
-                        {hypothesis.differentials.map((diff) => (
-                          <Badge key={diff} variant="outline" className="text-xs py-1 px-2">{diff}</Badge>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
+                  <InsightCard title="Explicação clínica" icon={BookOpen} tone="primary">
+                    <p>{hypothesis.explanation}</p>
+                  </InsightCard>
                 </div>
 
-                <div className="bg-muted/50 p-3 sm:p-4 rounded-lg border border-border/70">
-                  <h4 className="font-semibold mb-3 text-sm sm:text-base">🧪 Exames e red flags</h4>
-                  <div className="space-y-3 text-sm">
-                    <div>
-                      <p className="font-medium mb-2">Exames</p>
-                      <div className="flex flex-wrap gap-2">
-                        {hypothesis.recommendedExams.map((exam) => (
-                          <Badge key={exam} variant="secondary" className="text-xs">{exam}</Badge>
-                        ))}
+                <div className="grid gap-4 lg:grid-cols-2">
+                  <InsightCard title="Diagnósticos diferenciais" icon={Search} tone="neutral">
+                    <ListItems items={hypothesis.differentials} emptyText="Sem diferenciais listados." badge />
+                  </InsightCard>
+
+                  <InsightCard title="Exames e red flags" icon={AlertTriangle} tone="warning">
+                    <div className="space-y-3">
+                      <div>
+                        <p className="mb-2 font-bold text-slate-800">Exames</p>
+                        <ListItems items={hypothesis.recommendedExams} emptyText="Sem exames específicos." badge />
+                      </div>
+                      <div>
+                        <p className="mb-2 font-bold text-slate-800">Sinais de alarme</p>
+                        <div className="flex flex-wrap gap-2">
+                          {hypothesis.redFlags.map((flag) => (
+                            <Badge key={flag} variant="outline" className="border-destructive/30 bg-rose-50 text-destructive">
+                              {flag}
+                            </Badge>
+                          ))}
+                        </div>
                       </div>
                     </div>
-                    <div>
-                      <p className="font-medium mb-2">Sinais de alarme</p>
-                      <div className="flex flex-wrap gap-2">
-                        {hypothesis.redFlags.map((flag) => (
-                          <Badge key={flag} variant="outline" className="text-xs border-destructive/30 text-destructive">{flag}</Badge>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
+                  </InsightCard>
                 </div>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
+              </CardContent>
+            </Card>
+          );
+        })}
       </div>
 
-      <Card className="bg-gradient-to-r from-warning-soft/50 to-orange-50/50 border-warning shadow-lg">
+      <Card className="overflow-hidden rounded-2xl border-warning/40 bg-warning-soft/60 shadow-sm">
         <CardContent className="p-4 sm:p-6">
           <div className="flex items-start gap-3">
-            <div className="p-2 bg-warning/20 rounded-full">
-              <AlertTriangle className="h-6 w-6 text-warning flex-shrink-0" />
+            <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-warning/20 text-warning">
+              <AlertTriangle className="h-6 w-6" />
             </div>
-            <div className="flex-1">
-              <h3 className="font-bold text-warning text-lg sm:text-xl mb-3">⚠️ Aviso educacional importante</h3>
-              <p className="text-warning/90 leading-relaxed text-sm sm:text-base">
+            <div>
+              <h3 className="text-lg font-semibold text-warning sm:text-xl">Aviso educacional importante</h3>
+              <p className="mt-2 text-sm leading-7 text-warning/90 sm:text-base">
                 Este simulador é uma ferramenta <strong>exclusivamente educacional</strong>. As sugestões apresentadas não constituem diagnóstico médico definitivo nem prescrição terapêutica. Sempre consulte um profissional qualificado antes de tomar qualquer decisão clínica real.
               </p>
             </div>
@@ -358,5 +402,79 @@ export const DiagnosisResult = ({ diagnosis, patientData, onReset }: DiagnosisRe
         </CardContent>
       </Card>
     </div>
+  );
+};
+
+interface InfoTileProps {
+  icon: LucideIcon;
+  label: string;
+  value: string | number;
+  capitalize?: boolean;
+}
+
+const InfoTile = ({ icon: Icon, label, value, capitalize = false }: InfoTileProps) => (
+  <div className="flex items-center gap-3 rounded-xl border border-slate-200 bg-white p-4">
+    <Icon className="h-5 w-5 flex-shrink-0 text-primary" />
+    <div className="min-w-0">
+      <p className="text-xs font-bold uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className={`truncate font-bold text-slate-900 ${capitalize ? 'capitalize' : ''}`}>{value}</p>
+    </div>
+  </div>
+);
+
+interface InsightCardProps {
+  title: string;
+  icon: LucideIcon;
+  tone: 'primary' | 'success' | 'warning' | 'danger' | 'neutral';
+  children: ReactNode;
+}
+
+const toneClasses: Record<InsightCardProps['tone'], string> = {
+  primary: 'border-primary/15 bg-primary-soft/40 text-primary',
+  success: 'border-success/15 bg-success-soft/60 text-success',
+  warning: 'border-warning/20 bg-warning-soft/60 text-warning',
+  danger: 'border-destructive/20 bg-rose-50 text-destructive',
+  neutral: 'border-slate-200/80 bg-slate-50/80 text-slate-700',
+};
+
+const InsightCard = ({ title, icon: Icon, tone, children }: InsightCardProps) => (
+  <div className={`rounded-xl border p-4 text-sm leading-7 ${toneClasses[tone]}`}>
+    <div className="mb-3 flex items-center gap-2 font-semibold">
+      <Icon className="h-5 w-5 flex-shrink-0" />
+      <h4>{title}</h4>
+    </div>
+    <div className="text-current/90">{children}</div>
+  </div>
+);
+
+interface ListItemsProps {
+  items: string[];
+  emptyText: string;
+  badge?: boolean;
+}
+
+const ListItems = ({ items, emptyText, badge = false }: ListItemsProps) => {
+  if (items.length === 0) {
+    return <p className="text-sm opacity-80">{emptyText}</p>;
+  }
+
+  if (badge) {
+    return (
+      <div className="flex flex-wrap gap-2">
+        {items.map((item) => (
+          <Badge key={item} variant="outline" className="border-current/20 bg-white text-current">
+            {item}
+          </Badge>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <ul className="list-disc space-y-1 pl-5">
+      {items.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
   );
 };

--- a/src/components/PatientForm.tsx
+++ b/src/components/PatientForm.tsx
@@ -1,13 +1,23 @@
-import { useState } from "react";
-import React from "react";
+import { lazy, Suspense, useMemo, useState, type FormEvent } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { VoiceAssistant } from "@/components/voice/VoiceAssistant";
-import { Loader2, UserCheck, ClipboardList, Stethoscope } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { AlertCircle, CheckCircle2, ClipboardList, Loader2, Mic2, Sparkles, Stethoscope, Target, UserCheck, Wand2 } from "lucide-react";
+
+const VoiceAssistant = lazy(() =>
+  import("@/components/voice/VoiceAssistant").then((module) => ({ default: module.VoiceAssistant })),
+);
+
+const voiceFallback = (
+  <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm font-medium text-muted-foreground">
+    Preparando ditado clínico...
+  </div>
+);
 
 interface PatientData {
   name: string;
@@ -25,29 +35,63 @@ interface PatientFormProps {
 
 const SYMPTOM_CATEGORIES = {
   cardiovascular: [
-    "Dor torácica", "Palpitações", "Dispneia", "Edema de membros inferiores", 
-    "Síncope", "Cianose", "Claudicação intermitente"
+    "Dor torácica",
+    "Palpitações",
+    "Dispneia",
+    "Edema de membros inferiores",
+    "Síncope",
+    "Cianose",
+    "Claudicação intermitente",
   ],
   respiratorio: [
-    "Tosse seca", "Tosse produtiva", "Dispneia aos esforços", "Dispneia de repouso",
-    "Hemoptise", "Dor pleurítica", "Sibilos"
+    "Tosse seca",
+    "Tosse produtiva",
+    "Dispneia aos esforços",
+    "Dispneia de repouso",
+    "Hemoptise",
+    "Dor pleurítica",
+    "Sibilos",
   ],
   gastrointestinal: [
-    "Dor epigástrica", "Dor em hipocôndrio direito", "Dor em fossa ilíaca direita",
-    "Náuseas", "Vômitos", "Diarreia", "Constipação", "Melena", "Hematoquezia"
+    "Dor epigástrica",
+    "Dor em hipocôndrio direito",
+    "Dor em fossa ilíaca direita",
+    "Náuseas",
+    "Vômitos",
+    "Diarreia",
+    "Constipação",
+    "Melena",
+    "Hematoquezia",
   ],
   neurologico: [
-    "Cefaleia", "Tontura", "Vertigem", "Parestesias", "Paresia", "Convulsões",
-    "Alteração da consciência", "Distúrbios visuais"
+    "Cefaleia",
+    "Tontura",
+    "Vertigem",
+    "Parestesias",
+    "Paresia",
+    "Convulsões",
+    "Alteração da consciência",
+    "Distúrbios visuais",
   ],
   genitourinario: [
-    "Disúria", "Polaciúria", "Hematúria", "Dor lombar", "Retenção urinária",
-    "Oligúria", "Anúria"
+    "Disúria",
+    "Polaciúria",
+    "Hematúria",
+    "Dor lombar",
+    "Retenção urinária",
+    "Oligúria",
+    "Anúria",
   ],
-  sistemico: [
-    "Febre", "Calafrios", "Sudorese", "Fadiga", "Perda de peso", "Anorexia",
-    "Mialgia", "Artralgia"
-  ]
+  sistemico: ["Febre", "Calafrios", "Sudorese", "Fadiga", "Perda de peso", "Anorexia", "Mialgia", "Artralgia"],
+};
+
+const CATEGORY_LABELS: Record<keyof typeof SYMPTOM_CATEGORIES, string> = {
+  cardiovascular: "Cardio",
+  respiratorio: "Resp.",
+  gastrointestinal: "Gastro",
+  neurologico: "Neuro",
+  genitourinario: "GU",
+  sistemico: "Sistêmico",
 };
 
 const DURATION_OPTIONS = [
@@ -55,7 +99,100 @@ const DURATION_OPTIONS = [
   { value: "6-24h", label: "6 a 24 horas", severity: "agudo" },
   { value: "1-7d", label: "1 a 7 dias", severity: "agudo" },
   { value: "1-4sem", label: "1 a 4 semanas", severity: "subagudo" },
-  { value: "> 4sem", label: "Mais de 4 semanas", severity: "cronico" }
+  { value: "> 4sem", label: "Mais de 4 semanas", severity: "crônico" },
+];
+
+const CASE_TEMPLATES: Array<{
+  title: string;
+  description: string;
+  category: keyof typeof SYMPTOM_CATEGORIES;
+  data: PatientData;
+}> = [
+  {
+    title: "Dor torácica",
+    description: "Caso cardiovascular com red flags claras.",
+    category: "cardiovascular",
+    data: {
+      name: "Caso 01",
+      age: 58,
+      gender: "masculino",
+      duration: "6-24h",
+      symptoms:
+        "Dor torácica intensa há 8 horas, em aperto, piora ao esforço e melhora parcial em repouso. Associada a dispneia, náuseas e sudorese. Nega febre. Antecedentes de hipertensão, tabagismo e dislipidemia.",
+    },
+  },
+  {
+    title: "Dispneia febril",
+    description: "Treino respiratório com contexto infeccioso.",
+    category: "respiratorio",
+    data: {
+      name: "Caso 02",
+      age: 42,
+      gender: "feminino",
+      duration: "1-7d",
+      symptoms:
+        "Dispneia progressiva desde há 4 dias, moderada, piora aos esforços. Associada a tosse produtiva, febre, calafrios e dor pleurítica. Nega dor torácica em aperto. Sem alergias conhecidas, sem tabagismo.",
+    },
+  },
+  {
+    title: "Dor abdominal",
+    description: "Raciocínio gastro com cronologia objetiva.",
+    category: "gastrointestinal",
+    data: {
+      name: "Caso 03",
+      age: 27,
+      gender: "feminino",
+      duration: "6-24h",
+      symptoms:
+        "Dor abdominal iniciada há 14 horas, inicialmente periumbilical e evoluiu para fossa ilíaca direita. Intensidade forte, piora ao movimento. Associada a náuseas, anorexia e vômitos. Nega diarreia e nega sintomas urinários. Sem comorbidades conhecidas.",
+    },
+  },
+];
+
+const requiredFields: Array<keyof Pick<PatientData, "age" | "gender" | "symptoms" | "duration">> = [
+  "age",
+  "gender",
+  "symptoms",
+  "duration",
+];
+
+const QUALITY_CRITERIA = [
+  {
+    label: "Cronologia",
+    hint: "quando começou e como evoluiu",
+    patterns: ["início", "iniciou", "começou", "desde", "há ", "evoluiu", "evolução"],
+    snippet: "Início há ___, evolução ___ desde o começo dos sintomas.",
+  },
+  {
+    label: "Intensidade",
+    hint: "leve/moderada/intensa ou escala de dor",
+    patterns: ["leve", "moderada", "intensa", "forte", "escala", "/10", "nota"],
+    snippet: "Intensidade ___/10, caracterizada como ___ e impacto funcional ___.",
+  },
+  {
+    label: "Fatores",
+    hint: "melhora, piora, gatilhos ou relação com esforço",
+    patterns: ["melhora", "piora", "gatilho", "esforço", "repouso", "aliment", "movimento"],
+    snippet: "Piora com ___, melhora com ___, gatilhos percebidos ___.",
+  },
+  {
+    label: "Associados",
+    hint: "sintomas acompanhando a queixa principal",
+    patterns: ["associad", "junto", "também", "náuse", "febre", "dispneia", "sudorese", "vômit"],
+    snippet: "Sintomas associados: ___.",
+  },
+  {
+    label: "Negativos",
+    hint: "nega sintomas importantes e red flags ausentes",
+    patterns: ["nega", "sem ", "ausência", "não apresenta", "não refere"],
+    snippet: "Nega ___, sem ___, não refere ___.",
+  },
+  {
+    label: "Contexto",
+    hint: "antecedentes, medicações, alergias ou risco",
+    patterns: ["anteced", "medica", "alerg", "comorb", "hipert", "diabet", "tabag", "gest"],
+    snippet: "Antecedentes: ___. Medicações: ___. Alergias: ___.",
+  },
 ];
 
 export const PatientForm = ({ onSubmit, isAnalyzing, patientData }: PatientFormProps) => {
@@ -64,12 +201,36 @@ export const PatientForm = ({ onSubmit, isAnalyzing, patientData }: PatientFormP
     age: 0,
     gender: "",
     symptoms: "",
-    duration: ""
+    duration: "",
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});
-  const [activeCategory, setActiveCategory] = useState<string | null>(null);
-  const [isMobile, setIsMobile] = useState(false);
+  const [activeCategory, setActiveCategory] = useState<keyof typeof SYMPTOM_CATEGORIES>("cardiovascular");
+
+  const completion = useMemo(() => {
+    const completed = requiredFields.filter((field) => {
+      const value = formData[field];
+      return typeof value === "number" ? value > 0 : Boolean(value.trim());
+    }).length;
+
+    return Math.round((completed / requiredFields.length) * 100);
+  }, [formData]);
+
+  const qualityChecks = useMemo(() => {
+    const normalizedSymptoms = formData.symptoms.toLowerCase();
+
+    return QUALITY_CRITERIA.map((criterion) => ({
+      ...criterion,
+      done: criterion.patterns.some((pattern) => normalizedSymptoms.includes(pattern)),
+    }));
+  }, [formData.symptoms]);
+
+  const qualityScore = useMemo(() => {
+    const done = qualityChecks.filter((check) => check.done).length;
+    return Math.round((done / qualityChecks.length) * 100);
+  }, [qualityChecks]);
+
+  const qualityLabel = qualityScore >= 85 ? "Anamnese elite" : qualityScore >= 55 ? "Boa base clínica" : "Enriqueça o caso";
 
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
@@ -94,7 +255,7 @@ export const PatientForm = ({ onSubmit, isAnalyzing, patientData }: PatientFormP
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
     if (validateForm()) {
       onSubmit(formData);
@@ -103,36 +264,32 @@ export const PatientForm = ({ onSubmit, isAnalyzing, patientData }: PatientFormP
 
   const appendSymptomsText = (text: string) => {
     const currentSymptoms = formData.symptoms.trim();
-    const nextSymptoms = currentSymptoms
-      ? `${currentSymptoms}, ${text}`
-      : text;
+    const nextSymptoms = currentSymptoms ? `${currentSymptoms}, ${text}` : text;
     setFormData({ ...formData, symptoms: nextSymptoms });
   };
 
-  const addSymptom = (symptom: string) => {
-    appendSymptomsText(symptom);
+  const applyTemplate = (template: (typeof CASE_TEMPLATES)[number]) => {
+    setFormData(template.data);
+    setActiveCategory(template.category);
+    setErrors({});
   };
-
-  // Mobile detection
-  React.useEffect(() => {
-    const handleResize = () => setIsMobile(window.innerWidth < 768);
-    handleResize();
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
 
   if (patientData && isAnalyzing) {
     return (
-      <Card className="border-primary/20">
-        <CardContent className="p-8">
-          <div className="text-center space-y-4">
-            <Loader2 className="h-12 w-12 animate-spin text-primary mx-auto" />
-            <h3 className="text-xl font-semibold">Analisando caso clínico...</h3>
-            <p className="text-muted-foreground">
-              Processando dados do paciente <strong>{patientData.name}</strong>
-            </p>
-            <div className="bg-primary-soft p-4 rounded-lg">
-              <p className="text-sm">
+      <Card className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <CardContent className="p-6 sm:p-10">
+          <div className="mx-auto max-w-2xl space-y-5 text-center">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-primary-soft text-primary">
+              <Loader2 className="h-9 w-9 animate-spin" />
+            </div>
+            <div>
+              <h3 className="text-2xl font-semibold text-slate-950">Analisando caso clínico...</h3>
+              <p className="mt-2 text-muted-foreground">
+                Processando dados do paciente <strong>{patientData.name || "fictício"}</strong> com foco educacional.
+              </p>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-left">
+              <p className="text-sm leading-6 text-primary/90">
                 <strong>Sintomas:</strong> {patientData.symptoms}
               </p>
             </div>
@@ -143,210 +300,258 @@ export const PatientForm = ({ onSubmit, isAnalyzing, patientData }: PatientFormP
   }
 
   return (
-    <Card className="border-primary/20 shadow-lg animate-fade-in">
-      <CardHeader className="bg-gradient-to-r from-primary-soft via-primary-soft/80 to-accent border-b">
-        <div className="flex items-center gap-3">
-          <div className="p-2 bg-primary/20 rounded-lg">
-            <ClipboardList className="h-6 w-6 text-primary" />
+    <Card className="animate-fade-in overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <CardHeader className="border-b border-slate-200 bg-white p-5 sm:p-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-start gap-3">
+            <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-primary-soft text-primary">
+              <ClipboardList className="h-6 w-6" />
+            </div>
+            <div>
+              <Badge variant="outline" className="mb-2 border-slate-200 bg-slate-50 text-slate-600">
+                <Sparkles className="mr-1 h-3 w-3" />
+                Fluxo premium de anamnese
+              </Badge>
+              <CardTitle className="text-xl font-semibold text-slate-950 sm:text-2xl">Anamnese do Paciente</CardTitle>
+              <CardDescription className="mt-1 text-sm sm:text-base">
+                Preencha o caso clínico fictício com campos amplos, toque confortável e atalhos por sistema.
+              </CardDescription>
+            </div>
           </div>
-          <div>
-            <CardTitle className="text-lg sm:text-xl">Anamnese do Paciente</CardTitle>
-            <CardDescription className="text-sm sm:text-base">
-              Preencha os dados do caso clínico fictício para análise
-            </CardDescription>
+
+          <div className="min-w-[12rem] rounded-xl border border-slate-200 bg-slate-50 p-3">
+            <div className="mb-2 flex items-center justify-between text-xs font-bold uppercase tracking-wide text-slate-500">
+              <span>Completude</span>
+              <span>{completion}%</span>
+            </div>
+            <Progress value={completion} className="h-2.5" />
           </div>
         </div>
       </CardHeader>
 
-      <CardContent className="p-4 pb-24 sm:p-6 sm:pb-6">
-        <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-6">
-          {/* Nome do Paciente */}
-          <div className="space-y-2">
-            <Label htmlFor="name" className="flex items-center gap-2">
-              <UserCheck className="h-4 w-4" />
-              Nome do Paciente (Fictício)
-            </Label>
-            <Input
-              id="name"
-              placeholder="Ex: João Silva (caso simulado)"
-              value={formData.name}
-              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-              className="h-11 sm:h-12 text-base border-border focus:ring-2 focus:ring-primary/20"
-            />
-          </div>
-
-          {/* Idade e Gênero */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <CardContent className="p-4 pb-28 sm:p-6 sm:pb-6">
+        <form onSubmit={handleSubmit} className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_22rem] lg:gap-8">
+          <div className="space-y-5">
             <div className="space-y-2">
-              <Label htmlFor="age" className="text-base font-medium">Idade *</Label>
+              <Label htmlFor="name" className="flex items-center gap-2 text-sm font-bold text-slate-800">
+                <UserCheck className="h-4 w-4 text-primary" />
+                Nome do paciente (fictício)
+              </Label>
               <Input
-                id="age"
-                type="number"
-                min="1"
-                max="120"
-                placeholder="Ex: 35"
-                value={formData.age || ""}
-                onChange={(e) => setFormData({ ...formData, age: parseInt(e.target.value) || 0 })}
-                className={`h-11 sm:h-12 text-base focus:ring-2 focus:ring-primary/20 ${errors.age ? "border-destructive" : "border-border"}`}
+                id="name"
+                autoComplete="off"
+                placeholder="Ex: João Silva (caso simulado)"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                className="h-11 rounded-xl border-slate-200 bg-white text-base focus-visible:ring-primary/25"
               />
-              {errors.age && <p className="text-sm text-destructive">{errors.age}</p>}
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="age" className="text-sm font-bold text-slate-800">Idade *</Label>
+                <Input
+                  id="age"
+                  type="number"
+                  min="1"
+                  max="120"
+                  inputMode="numeric"
+                  placeholder="Ex: 35"
+                  value={formData.age || ""}
+                  onChange={(e) => setFormData({ ...formData, age: parseInt(e.target.value, 10) || 0 })}
+                  className={`h-11 rounded-xl bg-white text-base focus-visible:ring-primary/25 ${errors.age ? "border-destructive" : "border-slate-200"}`}
+                />
+                {errors.age && <FieldError message={errors.age} />}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="gender" className="text-sm font-bold text-slate-800">Gênero *</Label>
+                <Select value={formData.gender} onValueChange={(value) => setFormData({ ...formData, gender: value })}>
+                  <SelectTrigger className={`h-11 rounded-xl bg-white text-base focus:ring-primary/25 ${errors.gender ? "border-destructive" : "border-slate-200"}`}>
+                    <SelectValue placeholder="Selecione o gênero" />
+                  </SelectTrigger>
+                  <SelectContent className="z-50 bg-background">
+                    <SelectItem value="masculino">Masculino</SelectItem>
+                    <SelectItem value="feminino">Feminino</SelectItem>
+                    <SelectItem value="outro">Outro</SelectItem>
+                    <SelectItem value="nao-informar">Prefiro não informar</SelectItem>
+                  </SelectContent>
+                </Select>
+                {errors.gender && <FieldError message={errors.gender} />}
+              </div>
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="gender" className="text-base font-medium">Gênero *</Label>
-              <Select
-                value={formData.gender}
-                onValueChange={(value) => setFormData({ ...formData, gender: value })}
-              >
-                <SelectTrigger className={`h-11 sm:h-12 text-base focus:ring-2 focus:ring-primary/20 ${errors.gender ? "border-destructive" : "border-border"}`}>
-                  <SelectValue placeholder="Selecione o gênero" />
+              <Label htmlFor="duration" className="text-sm font-bold text-slate-800">Duração dos sintomas *</Label>
+              <Select value={formData.duration} onValueChange={(value) => setFormData({ ...formData, duration: value })}>
+                <SelectTrigger className={`h-11 rounded-xl bg-white text-base focus:ring-primary/25 ${errors.duration ? "border-destructive" : "border-slate-200"}`}>
+                  <SelectValue placeholder="Há quanto tempo os sintomas começaram?" />
                 </SelectTrigger>
-                <SelectContent className="bg-background z-50">
-                  <SelectItem value="masculino">Masculino</SelectItem>
-                  <SelectItem value="feminino">Feminino</SelectItem>
-                  <SelectItem value="outro">Outro</SelectItem>
-                  <SelectItem value="nao-informar">Prefiro não informar</SelectItem>
+                <SelectContent className="z-50 bg-background">
+                  {DURATION_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                      <span className="ml-2 text-xs text-muted-foreground">({option.severity})</span>
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
-              {errors.gender && <p className="text-sm text-destructive">{errors.gender}</p>}
+              {errors.duration && <FieldError message={errors.duration} />}
             </div>
-          </div>
 
-          {/* Duração dos Sintomas */}
-          <div className="space-y-2">
-            <Label htmlFor="duration" className="text-base font-medium">Duração dos Sintomas *</Label>
-            <Select
-              value={formData.duration}
-              onValueChange={(value) => setFormData({ ...formData, duration: value })}
-            >
-              <SelectTrigger className={`h-11 sm:h-12 text-base focus:ring-2 focus:ring-primary/20 ${errors.duration ? "border-destructive" : "border-border"}`}>
-                <SelectValue placeholder="Há quanto tempo os sintomas começaram?" />
-              </SelectTrigger>
-              <SelectContent className="bg-background z-50">
-                {DURATION_OPTIONS.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                    <span className="ml-2 text-xs text-muted-foreground">
-                      ({option.severity})
-                    </span>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {errors.duration && <p className="text-sm text-destructive">{errors.duration}</p>}
-          </div>
-
-          {/* Sintomas */}
-          <div className="space-y-4">
-            <Label htmlFor="symptoms" className="text-base font-medium">Sintomas Apresentados *</Label>
-            <Textarea
-              id="symptoms"
-              placeholder="Descreva detalhadamente os sintomas do paciente..."
-              value={formData.symptoms}
-              onChange={(e) => setFormData({ ...formData, symptoms: e.target.value })}
-              rows={isMobile ? 3 : 4}
-              className={`text-base min-h-[100px] focus:ring-2 focus:ring-primary/20 ${errors.symptoms ? "border-destructive" : "border-border"}`}
-            />
-            {errors.symptoms && <p className="text-sm text-destructive">{errors.symptoms}</p>}
-
-            <VoiceAssistant
-              title="Ditado clínico"
-              description="Toque no microfone para ditar sintomas em português. O texto capturado será anexado à anamnese."
-              listenLabel="Falar sintomas"
-              onTranscript={appendSymptomsText}
-              disabled={isAnalyzing}
-            />
-            
-            {/* Sugestões de Sintomas por Sistema */}
             <div className="space-y-3">
-              <p className="text-sm font-medium text-foreground">Sugestões por sistema:</p>
-              
-              {/* Category buttons for mobile */}
-              {isMobile ? (
-                <div className="space-y-3">
-                  <div className="grid grid-cols-2 gap-2">
-                    {Object.entries(SYMPTOM_CATEGORIES).map(([category, symptoms]) => (
-                      <Button
-                        key={category}
-                        type="button"
-                        variant={activeCategory === category ? "default" : "outline"}
-                        size="sm"
-                        onClick={() => setActiveCategory(activeCategory === category ? null : category)}
-                        className="h-10 text-xs capitalize"
-                      >
-                        {category.replace(/([A-Z])/g, ' $1').trim()}
-                        <span className="ml-1 text-xs">({symptoms.length})</span>
-                      </Button>
-                    ))}
-                  </div>
-                  
-                  {/* Active category symptoms */}
-                  {activeCategory && (
-                    <div className="space-y-2">
-                      <p className="text-xs text-muted-foreground capitalize font-medium">
-                        Sistema {activeCategory}:
-                      </p>
-                      <div className="grid grid-cols-1 gap-2">
-                        {SYMPTOM_CATEGORIES[activeCategory as keyof typeof SYMPTOM_CATEGORIES].map((symptom) => (
-                          <Button
-                            key={symptom}
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() => addSymptom(symptom)}
-                            className="h-10 text-xs justify-start"
-                          >
-                            + {symptom}
-                          </Button>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                /* Desktop view */
-                <div className="space-y-3">
-                  {Object.entries(SYMPTOM_CATEGORIES).map(([category, symptoms]) => (
-                    <div key={category} className="space-y-2">
-                      <p className="text-xs font-medium text-muted-foreground capitalize">
-                        {category.replace(/([A-Z])/g, ' $1').trim()}:
-                      </p>
-                      <div className="flex flex-wrap gap-2">
-                        {symptoms.map((symptom) => (
-                          <Button
-                            key={symptom}
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() => addSymptom(symptom)}
-                            className="h-8 text-xs"
-                          >
-                            + {symptom}
-                          </Button>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
+              <Label htmlFor="symptoms" className="text-sm font-bold text-slate-800">Sintomas apresentados *</Label>
+              <Textarea
+                id="symptoms"
+                placeholder="Descreva sintomas, início, fatores de melhora/piora, antecedentes e contexto do caso fictício..."
+                value={formData.symptoms}
+                onChange={(e) => setFormData({ ...formData, symptoms: e.target.value })}
+                rows={5}
+                className={`min-h-[9rem] rounded-xl bg-white p-4 text-base leading-7 focus-visible:ring-primary/25 ${errors.symptoms ? "border-destructive" : "border-slate-200"}`}
+              />
+              {errors.symptoms && <FieldError message={errors.symptoms} />}
+
+              <Suspense fallback={voiceFallback}>
+                <VoiceAssistant
+                  title="Ditado clínico"
+                  description="Toque no microfone para ditar sintomas em português. O texto capturado será anexado à anamnese."
+                  listenLabel="Falar sintomas"
+                  onTranscript={appendSymptomsText}
+                  disabled={isAnalyzing}
+                />
+              </Suspense>
             </div>
           </div>
 
-          {/* Submit Button */}
-          <div className="fixed inset-x-0 bottom-0 z-20 border-t bg-background/95 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] backdrop-blur md:static md:border-0 md:bg-transparent md:p-0">
+          <aside className="space-y-4 lg:sticky lg:top-28 lg:self-start">
+            <div className="rounded-2xl border border-slate-200 bg-white p-4">
+              <div className="mb-3 flex items-start gap-2">
+                <Wand2 className="mt-0.5 h-4 w-4 text-primary" />
+                <div>
+                  <p className="text-sm font-semibold text-slate-900">Casos rápidos</p>
+                  <p className="text-xs leading-5 text-muted-foreground">Preencha um caso completo e edite livremente.</p>
+                </div>
+              </div>
+              <div className="grid gap-2">
+                {CASE_TEMPLATES.map((template) => (
+                  <Button
+                    key={template.title}
+                    type="button"
+                    variant="outline"
+                    onClick={() => applyTemplate(template)}
+                    className="h-auto justify-start rounded-xl border-slate-200 bg-slate-50 px-3 py-2 text-left hover:bg-white"
+                  >
+                    <span>
+                      <span className="block text-xs font-semibold text-slate-900">{template.title}</span>
+                      <span className="block text-[11px] font-normal leading-4 text-muted-foreground">{template.description}</span>
+                    </span>
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-white p-4">
+              <div className="mb-3 flex items-start justify-between gap-3">
+                <div>
+                  <p className="flex items-center gap-2 text-sm font-semibold text-slate-900">
+                    <Target className="h-4 w-4 text-violet-600" />
+                    Qualidade da anamnese
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">{qualityLabel} • {qualityScore}% de contexto clínico</p>
+                </div>
+                <Badge variant="outline" className="border-violet-200 bg-white/80 text-violet-700">
+                  {qualityChecks.filter((check) => check.done).length}/{qualityChecks.length}
+                </Badge>
+              </div>
+              <Progress value={qualityScore} className="mb-3 h-2.5" />
+              <div className="grid gap-2">
+                {qualityChecks.map((check) => (
+                  <div key={check.label} className="flex items-start gap-2 rounded-xl border border-slate-200 bg-slate-50 p-2.5">
+                    <CheckCircle2 className={`mt-0.5 h-4 w-4 flex-shrink-0 ${check.done ? "text-emerald-500" : "text-slate-300"}`} />
+                    <div>
+                      <p className="text-xs font-semibold text-slate-800">{check.label}</p>
+                      <p className="text-[11px] leading-4 text-muted-foreground">{check.hint}</p>
+                      {!check.done && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => appendSymptomsText(check.snippet)}
+                          className="mt-1 h-7 rounded-lg px-2 text-[11px] text-primary hover:bg-primary-soft"
+                        >
+                          Inserir guia
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-white p-4">
+              <div className="mb-3 flex items-center justify-between gap-2">
+                <div>
+                  <p className="text-sm font-semibold text-slate-900">Sugestões por sistema</p>
+                  <p className="text-xs text-muted-foreground">Toque para adicionar sem digitar.</p>
+                </div>
+                <Mic2 className="h-5 w-5 text-primary" />
+              </div>
+
+              <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-2 lg:grid lg:grid-cols-2 lg:overflow-visible">
+                {(Object.keys(SYMPTOM_CATEGORIES) as Array<keyof typeof SYMPTOM_CATEGORIES>).map((category) => (
+                  <Button
+                    key={category}
+                    type="button"
+                    variant={activeCategory === category ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => setActiveCategory(category)}
+                    className="h-10 flex-shrink-0 rounded-full px-4 text-xs font-bold lg:w-full"
+                  >
+                    {CATEGORY_LABELS[category]}
+                    <span className="ml-1 opacity-70">({SYMPTOM_CATEGORIES[category].length})</span>
+                  </Button>
+                ))}
+              </div>
+
+              <div className="mt-3 grid gap-2">
+                {SYMPTOM_CATEGORIES[activeCategory].map((symptom) => (
+                  <Button
+                    key={symptom}
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => appendSymptomsText(symptom)}
+                    className="min-h-10 justify-start rounded-2xl border-slate-200 bg-white/80 px-3 text-left text-xs font-semibold shadow-sm hover:border-primary/30 hover:bg-primary-soft"
+                  >
+                    + {symptom}
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+              <div className="mb-2 flex items-center gap-2 font-semibold">
+                <CheckCircle2 className="h-4 w-4" />
+                Dica premium
+              </div>
+              Inclua cronologia, intensidade, fatores associados e sinais negativos relevantes para enriquecer o raciocínio.
+            </div>
+          </aside>
+
+          <div className="fixed inset-x-0 bottom-0 z-20 border-t border-slate-200 bg-white p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] md:static md:col-span-full md:border-0 md:bg-transparent md:p-0">
             <Button
               type="submit"
-              className="w-full h-11 sm:h-12 text-base bg-gradient-to-r from-primary to-primary/90 hover:from-primary/90 hover:to-primary font-medium shadow-lg hover:shadow-xl transition-all duration-200"
+              className="h-11 w-full rounded-xl bg-primary text-base font-semibold shadow-sm transition-colors hover:bg-primary/90"
               disabled={isAnalyzing}
             >
               {isAnalyzing ? (
                 <>
-                  <Loader2 className="h-5 w-5 mr-2 animate-spin" />
+                  <Loader2 className="mr-2 h-5 w-5 animate-spin" />
                   Analisando caso clínico...
                 </>
               ) : (
                 <>
-                  <Stethoscope className="h-5 w-5 mr-2" />
+                  <Stethoscope className="mr-2 h-5 w-5" />
                   Analisar Caso Clínico
                 </>
               )}
@@ -357,3 +562,10 @@ export const PatientForm = ({ onSubmit, isAnalyzing, patientData }: PatientFormP
     </Card>
   );
 };
+
+const FieldError = ({ message }: { message: string }) => (
+  <p className="flex items-center gap-1.5 text-sm font-medium text-destructive">
+    <AlertCircle className="h-4 w-4" />
+    {message}
+  </p>
+);

--- a/src/components/SafetyWarning.tsx
+++ b/src/components/SafetyWarning.tsx
@@ -1,75 +1,50 @@
-import { AlertTriangle, BookOpen, Users, Shield } from "lucide-react";
+import { AlertTriangle, BookOpen, Shield, Users } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
+
+const safetyItems = [
+  {
+    title: "Didático",
+    text: "Treino com casos fictícios.",
+    icon: BookOpen,
+  },
+  {
+    title: "Não diagnóstico",
+    text: "Não substitui avaliação médica.",
+    icon: AlertTriangle,
+  },
+  {
+    title: "Emergência",
+    text: "Sintomas reais graves: SAMU 192.",
+    icon: Users,
+  },
+];
 
 export const SafetyWarning = () => {
   return (
-    <div className="container mx-auto px-4 py-4">
-      <Card className="border-warning bg-gradient-to-r from-warning-soft to-warning-soft/50 border-l-4 border-l-warning">
-        <CardContent className="p-6">
-          <div className="flex items-start gap-4">
-            <div className="p-3 bg-warning/20 rounded-full flex-shrink-0">
-              <Shield className="h-6 w-6 text-warning" />
-            </div>
-            
-            <div className="space-y-4 flex-1">
-              <div>
-                <h2 className="text-xl font-bold text-warning mb-2 flex items-center gap-2">
-                  <AlertTriangle className="h-5 w-5" />
-                  Aviso de Segurança e Uso Educacional
-                </h2>
-              </div>
-
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 text-sm">
-                <div className="flex items-start gap-3">
-                  <BookOpen className="h-5 w-5 text-warning mt-0.5 flex-shrink-0" />
-                  <div>
-                    <h3 className="font-semibold text-warning mb-1">
-                      Finalidade Educacional
-                    </h3>
-                    <p className="text-warning/80">
-                      Este sistema é destinado exclusivamente ao treinamento de estudantes 
-                      de medicina e profissionais da saúde para fins didáticos.
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex items-start gap-3">
-                  <AlertTriangle className="h-5 w-5 text-warning mt-0.5 flex-shrink-0" />
-                  <div>
-                    <h3 className="font-semibold text-warning mb-1">
-                      Não é Diagnóstico Real
-                    </h3>
-                    <p className="text-warning/80">
-                      As sugestões geradas não constituem diagnóstico médico real 
-                      nem substituem avaliação profissional qualificada.
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex items-start gap-3">
-                  <Users className="h-5 w-5 text-warning mt-0.5 flex-shrink-0" />
-                  <div>
-                    <h3 className="font-semibold text-warning mb-1">
-                      Consulte um Médico
-                    </h3>
-                    <p className="text-warning/80">
-                      Para sintomas reais, sempre procure um médico qualificado. 
-                      Em emergências, ligue 192 (SAMU) ou dirija-se ao pronto-socorro.
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="bg-warning/10 p-3 rounded-lg border border-warning/20">
-                <p className="text-warning font-medium text-center">
-                  🚨 <strong>EMERGÊNCIAS:</strong> Em caso de sintomas graves como dor no peito, 
-                  dificuldade respiratória ou perda de consciência, procure atendimento médico imediato!
-                </p>
-              </div>
-            </div>
+    <Card className="h-full rounded-2xl border-amber-200 bg-amber-50/70 shadow-sm">
+      <CardContent className="p-4 sm:p-5">
+        <div className="mb-4 flex items-start gap-3">
+          <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl bg-amber-100 text-amber-700">
+            <Shield className="h-5 w-5" />
           </div>
-        </CardContent>
-      </Card>
-    </div>
+          <div>
+            <h2 className="text-sm font-semibold text-amber-950">Aviso de segurança</h2>
+            <p className="mt-1 text-sm leading-5 text-amber-900/75">Ferramenta exclusivamente educacional.</p>
+          </div>
+        </div>
+
+        <div className="grid gap-2">
+          {safetyItems.map(({ title, text, icon: Icon }) => (
+            <div key={title} className="flex items-start gap-2 rounded-xl bg-white/60 p-3 text-sm">
+              <Icon className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-700" />
+              <div>
+                <p className="font-medium text-amber-950">{title}</p>
+                <p className="text-amber-900/75">{text}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,10 +1,25 @@
-import { useEffect, useState } from 'react';
-import { DiagnosisResult } from '@/components/DiagnosisResult';
-import { PatientForm } from '@/components/PatientForm';
+import { Suspense, lazy, useEffect, useState } from 'react';
 import { SafetyWarning } from '@/components/SafetyWarning';
 import { analyzeClinicalCase } from '@/lib/aiClient';
 import { clearStoredClinicalSession, getStoredClinicalSession, saveClinicalSession } from '@/lib/sessionStore';
-import { ClinicalAssessment, PatientData } from '@/lib/medicalKnowledge';
+import type { ClinicalAssessment, PatientData } from '@/lib/medicalKnowledge';
+import { CheckCircle2, Loader2, ShieldCheck, Stethoscope } from 'lucide-react';
+
+const PatientForm = lazy(() =>
+  import('@/components/PatientForm').then((module) => ({ default: module.PatientForm })),
+);
+const DiagnosisResult = lazy(() =>
+  import('@/components/DiagnosisResult').then((module) => ({ default: module.DiagnosisResult })),
+);
+
+const LoadingPanel = () => (
+  <div className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
+    <div className="flex items-center justify-center gap-3 text-sm font-medium text-slate-600">
+      <Loader2 className="h-5 w-5 animate-spin text-primary" />
+      Carregando módulo clínico...
+    </div>
+  </div>
+);
 
 const Index = () => {
   const [patientData, setPatientData] = useState<PatientData | null>(null);
@@ -42,37 +57,67 @@ const Index = () => {
   };
 
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.98),_rgba(240,247,255,0.95)_55%,_rgba(232,244,255,0.9)_100%)] pb-[max(env(safe-area-inset-bottom),1rem)] pt-[max(env(safe-area-inset-top),0px)] text-foreground">
-      <header className="sticky top-0 z-30 border-b border-border/60 bg-white/85 backdrop-blur-sm">
-        <div className="mx-auto flex w-full max-w-6xl items-center gap-3 px-4 py-4 sm:px-6 sm:py-6">
-          <div className="rounded-xl bg-primary/10 p-1.5 shadow-sm">
+    <div className="min-h-screen bg-slate-50 pb-[max(env(safe-area-inset-bottom),1rem)] pt-[max(env(safe-area-inset-top),0px)] text-slate-950">
+      <header className="sticky top-0 z-30 border-b border-slate-200 bg-white/95 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-3 px-4 py-3 sm:px-6">
+          <div className="flex min-w-0 items-center gap-3">
             <img
               src="/aix8c-logo.svg"
               alt="AIX8C logo"
-              className="h-8 w-8 sm:h-9 sm:w-9 rounded-lg"
-              loading="eager"
+              width="36"
+              height="36"
+              decoding="async"
+              fetchPriority="high"
+              className="h-9 w-9 rounded-xl border border-slate-200 bg-white"
             />
+            <div className="min-w-0">
+              <h1 className="truncate text-base font-semibold tracking-tight sm:text-lg">Dr. IA — Simulador Clínico</h1>
+              <p className="hidden text-sm text-slate-500 sm:block">Anamnese guiada para casos educacionais fictícios.</p>
+            </div>
           </div>
-          <div>
-            <h1 className="text-xl font-bold sm:text-2xl">Dr. IA — Anamnese e Simulador Clínico</h1>
-            <p className="text-sm text-muted-foreground sm:text-base">
-              Plataforma focada exclusivamente em coleta de anamnese e suporte educacional para simulação clínica.
-            </p>
+          <div className="hidden items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-xs font-medium text-emerald-700 sm:flex">
+            <ShieldCheck className="h-4 w-4" />
+            Educacional
           </div>
         </div>
       </header>
 
-      <SafetyWarning />
+      <main className="mx-auto w-full max-w-6xl px-4 pb-10 pt-5 sm:px-6 sm:pt-8">
+        <section className="mb-5 grid gap-4 lg:grid-cols-[1fr_22rem] lg:items-stretch">
+          <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
+            <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-xl bg-primary-soft text-primary">
+              <Stethoscope className="h-5 w-5" />
+            </div>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-primary">Clínica simulada</p>
+            <h2 className="max-w-3xl text-2xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+              Uma tela simples para coletar dados, analisar hipóteses e estudar com segurança.
+            </h2>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600 sm:text-base">
+              Interface limpa, rápida e focada no essencial: anamnese, triagem educacional, hipóteses, exames e sinais de alerta.
+            </p>
+            <div className="mt-5 flex flex-wrap gap-2 text-xs font-medium text-slate-600">
+              {['Mobile-first', 'Sem distrações', 'Uso educacional'].map((label) => (
+                <span key={label} className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5">
+                  <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+                  {label}
+                </span>
+              ))}
+            </div>
+          </div>
 
-      <main className="mx-auto grid w-full max-w-6xl gap-4 px-3 pb-10 pt-2 sm:gap-6 sm:px-6">
-        {!diagnosis || !patientData ? (
-          <PatientForm onSubmit={handleFormSubmit} isAnalyzing={isAnalyzing} patientData={patientData} />
-        ) : (
-          <DiagnosisResult diagnosis={diagnosis} patientData={patientData} onReset={handleReset} />
-        )}
+          <SafetyWarning />
+        </section>
+
+        <Suspense fallback={<LoadingPanel />}>
+          {!diagnosis || !patientData ? (
+            <PatientForm onSubmit={handleFormSubmit} isAnalyzing={isAnalyzing} patientData={patientData} />
+          ) : (
+            <DiagnosisResult diagnosis={diagnosis} patientData={patientData} onReset={handleReset} />
+          )}
+        </Suspense>
       </main>
 
-      <footer className="mx-auto w-full max-w-6xl px-4 pb-[max(env(safe-area-inset-bottom),1rem)] text-center text-xs text-muted-foreground sm:px-6 sm:text-sm">
+      <footer className="mx-auto w-full max-w-6xl px-4 pb-[max(env(safe-area-inset-bottom),1rem)] text-center text-xs text-slate-500 sm:px-6">
         AIX8C - @lorenzavolponi - Educação + Medicina + Tecnologia = Sucesso no aprendizado
       </footer>
     </div>


### PR DESCRIPTION
### Motivation
- Provide an internal, searchable educational evidence knowledge base to support clinical training and contextual references.
- Expose backend routes to surface and refresh curated evidence for the frontend and for automated testing.
- Improve the clinical UI/UX to make anamnese entry, triage feedback, and result presentation clearer and more actionable for educational use.

### Description
- Add `backend/evidenceAgent.ts` implementing a seeded internal KB, remote refresh (`refreshEvidenceFromSources`), persistent store, simple full-text search (`searchEvidence`) and status reporting (`getEvidenceStatus`).
- Wire new API routes in `backend/server.ts`: `GET /api/evidence/status`, `GET /api/evidence/search` and `POST /api/evidence/refresh`, using the evidence agent functions `getEvidenceStatus`, `searchEvidence` and `refreshEvidenceFromSources`.
- Update backend tests in `backend/server.test.ts` to cover the evidence endpoints and remote-refresh flag behavior with assertions about response shape and safety messaging.
- Large frontend refactor across UI components: `DiagnosisResult.tsx` and `PatientForm.tsx` were redesigned with improved layout, lazy-loaded `VoiceAssistant`, progress and quality indicators, copy/export report functionality, new helper components (`InfoTile`, `InsightCard`, `ListItems`), and enriched templates/shortcuts for rapid case entry; `SafetyWarning.tsx` and `Index.tsx` were simplified and adapted to the new layout and lazy loading.

### Testing
- Ran the backend route test suite including `backend/server.test.ts` which verifies `GET /api/evidence/status`, `GET /api/evidence/search` and `POST /api/evidence/refresh`, and these tests passed.
- Exercised the updated server endpoints manually during development and persisted the evidence store file to validate `persistEvidenceStore`/`loadEvidenceStore` behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd1701d54832da1ae02369181b31c)